### PR TITLE
refactor(api): remove deprecated snapshot and ribbon file helpers

### DIFF
--- a/examples/client-library/README.md
+++ b/examples/client-library/README.md
@@ -32,14 +32,19 @@ replace github.com/dariasmyr/fts-engine => /absolute/path/to/fts-engine
 
 ## Examples in this folder
 
+Recommended path first:
+
 - `default/main.go` — minimal setup with defaults.
+- `snapshot/main.go` — save/load one snapshot payload in library mode.
 - `preset/main.go` — language preset via `pkg/ftspreset`.
+
+Additional scenarios:
+
 - `custom-options/main.go` — custom pipeline and extra options.
-- `snapshot/main.go` — save/load snapshot in pure library mode.
-- `snapshot-buffer-filter/main.go` — in-memory snapshot (`io.Writer`/`io.Reader`) with Bloom filter.
 - `filters-dynamic/main.go` — built-in dynamic filters (`bloom`, `cuckoo`).
 - `filter-ribbon/main.go` — built-in static `ribbon` filter + explicit finalize.
-- `ribbon-file/main.go` — ribbon build from files: default parser save, custom parser save, load from file, normalized `Contains`.
+- `snapshot-buffer-filter/main.go` — in-memory snapshot (`io.Writer`/`io.Reader`) with Bloom filter.
+- `ribbon-file/main.go` — advanced ribbon flow with file parsing adapters.
 
 Run each example from repository root:
 

--- a/examples/client-library/ribbon-file/main.go
+++ b/examples/client-library/ribbon-file/main.go
@@ -48,7 +48,7 @@ func runDefaultParserSave(tmpDir string) error {
 		return err
 	}
 
-	if err = rf.BuildWithRetriesFromFile(plainPath, 5); err != nil {
+	if err = rf.BuildWithRetriesFromKeyStream(parseFileKeyStream(plainPath, filter.ParseLineKeys), 5); err != nil {
 		return err
 	}
 
@@ -75,7 +75,7 @@ func runCustomParserSave(tmpDir string) error {
 		return err
 	}
 
-	if err = rf.BuildWithRetriesFromFileWithParser(csvPath, parseCSVSecondColumn, 5); err != nil {
+	if err = rf.BuildWithRetriesFromKeyStream(parseFileKeyStream(csvPath, parseCSVSecondColumn), 5); err != nil {
 		return err
 	}
 
@@ -138,6 +138,12 @@ func parseCSVSecondColumn(path string, emit func([]byte) bool) error {
 	}
 
 	return scanner.Err()
+}
+
+func parseFileKeyStream(path string, parser func(string, func([]byte) bool) error) func(func([]byte) bool) error {
+	return func(emit func([]byte) bool) error {
+		return parser(path, emit)
+	}
 }
 
 func saveRibbonToFile(rf *filter.RibbonFilter, path string) error {

--- a/pkg/filter/ribbon_file.go
+++ b/pkg/filter/ribbon_file.go
@@ -11,30 +11,6 @@ const ribbonScannerMaxTokenSize = 1024 * 1024
 
 type FileKeyParser func(path string, emit func([]byte) bool) error
 
-func (rf *RibbonFilter) BuildFromFile(path string) error {
-	return rf.BuildFromFileWithParser(path, ParseLineKeys)
-}
-
-func (rf *RibbonFilter) BuildWithRetriesFromFile(path string, maxAttempts uint32) error {
-	return rf.BuildWithRetriesFromFileWithParser(path, ParseLineKeys, maxAttempts)
-}
-
-func (rf *RibbonFilter) BuildFromFileWithParser(path string, parser FileKeyParser) error {
-	if parser == nil {
-		return fmt.Errorf("ribbon: nil key parser")
-	}
-
-	return rf.BuildFromKeyStream(fileParserKeyStream(path, parser))
-}
-
-func (rf *RibbonFilter) BuildWithRetriesFromFileWithParser(path string, parser FileKeyParser, maxAttempts uint32) error {
-	if parser == nil {
-		return fmt.Errorf("ribbon: nil key parser")
-	}
-
-	return rf.BuildWithRetriesFromKeyStream(fileParserKeyStream(path, parser), maxAttempts)
-}
-
 // ParseLineKeys parses plain text files where each non-empty line is one key.
 func ParseLineKeys(path string, emit func([]byte) bool) error {
 	if path == "" {
@@ -67,10 +43,4 @@ func ParseLineKeys(path string, emit func([]byte) bool) error {
 	}
 
 	return nil
-}
-
-func fileParserKeyStream(path string, parser FileKeyParser) func(func([]byte) bool) error {
-	return func(emit func([]byte) bool) error {
-		return parser(path, emit)
-	}
 }

--- a/pkg/filter/ribbon_test.go
+++ b/pkg/filter/ribbon_test.go
@@ -139,8 +139,12 @@ func TestRibbonFilterBuildFromFile(t *testing.T) {
 		t.Fatalf("NewRibbonFilter() error = %v", err)
 	}
 
-	if err := rf.BuildWithRetriesFromFile(path, 10); err != nil {
-		t.Fatalf("BuildWithRetriesFromFile() error = %v", err)
+	stream := func(emit func([]byte) bool) error {
+		return ParseLineKeys(path, emit)
+	}
+
+	if err := rf.BuildWithRetriesFromKeyStream(stream, 10); err != nil {
+		t.Fatalf("BuildWithRetriesFromKeyStream() error = %v", err)
 	}
 
 	for _, key := range []string{"alpha", "beta", "gamma"} {
@@ -183,8 +187,12 @@ func TestRibbonFilterBuildFromFileWithCustomParser(t *testing.T) {
 		t.Fatalf("NewRibbonFilter() error = %v", err)
 	}
 
-	if err := rf.BuildWithRetriesFromFileWithParser(path, parser, 10); err != nil {
-		t.Fatalf("BuildWithRetriesFromFileWithParser() error = %v", err)
+	stream := func(emit func([]byte) bool) error {
+		return parser(path, emit)
+	}
+
+	if err := rf.BuildWithRetriesFromKeyStream(stream, 10); err != nil {
+		t.Fatalf("BuildWithRetriesFromKeyStream() error = %v", err)
 	}
 
 	for _, key := range []string{"alpha", "beta", "gamma"} {

--- a/pkg/fts/engine.go
+++ b/pkg/fts/engine.go
@@ -1,7 +1,6 @@
 package fts
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -168,32 +167,6 @@ func (s *Service) Analyze() (Stats, bool) {
 
 func (s *Service) SaveSnapshot(w io.Writer, indexName string, filterName string) error {
 	return SaveSegmentSnapshot(w, indexName, s.index, filterName, s.filter)
-}
-
-func (s *Service) SaveSnapshotBuffered(w io.Writer, indexName string, filterName string) error {
-	if w == nil {
-		return fmt.Errorf("fts: save snapshot buffered: nil writer")
-	}
-
-	var buf bytes.Buffer
-	if err := s.SaveSnapshot(&buf, indexName, filterName); err != nil {
-		return err
-	}
-
-	if _, err := io.Copy(w, &buf); err != nil {
-		return fmt.Errorf("fts: save snapshot buffered: write destination: %w", err)
-	}
-
-	return nil
-}
-
-func (s *Service) SaveSnapshotBufferedAsync(w io.Writer, indexName string, filterName string) <-chan error {
-	errCh := make(chan error, 1)
-	go func() {
-		defer close(errCh)
-		errCh <- s.SaveSnapshotBuffered(w, indexName, filterName)
-	}()
-	return errCh
 }
 
 func (s *Service) SnapshotComponents() (Index, Filter) {

--- a/pkg/fts/snapshot_test.go
+++ b/pkg/fts/snapshot_test.go
@@ -132,7 +132,7 @@ func TestSaveSegmentSnapshotUnknownCodec(t *testing.T) {
 	}
 }
 
-func TestSaveSnapshotBufferedWritesPayload(t *testing.T) {
+func TestSaveSnapshotWritesPayload(t *testing.T) {
 	indexCodecName := fmt.Sprintf("test-index-%s", t.Name())
 	if err := RegisterIndexSnapshotCodec(indexCodecName,
 		func(index Index, w io.Writer) error { return index.(Serializable).Serialize(w) },
@@ -147,33 +147,10 @@ func TestSaveSnapshotBufferedWritesPayload(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	if err := svc.SaveSnapshotBuffered(&out, indexCodecName, ""); err != nil {
-		t.Fatalf("SaveSnapshotBuffered() error = %v", err)
+	if err := svc.SaveSnapshot(&out, indexCodecName, ""); err != nil {
+		t.Fatalf("SaveSnapshot() error = %v", err)
 	}
 	if out.Len() == 0 {
-		t.Fatal("SaveSnapshotBuffered() wrote empty payload")
-	}
-}
-
-func TestSaveSnapshotBufferedAsync(t *testing.T) {
-	indexCodecName := fmt.Sprintf("test-index-%s", t.Name())
-	if err := RegisterIndexSnapshotCodec(indexCodecName,
-		func(index Index, w io.Writer) error { return index.(Serializable).Serialize(w) },
-		loadSnapshotIndex,
-	); err != nil {
-		t.Fatalf("RegisterIndexSnapshotCodec() error = %v", err)
-	}
-
-	svc := New(newSnapshotIndex(), WordKeys)
-	if err := svc.IndexDocument(context.Background(), "doc-1", "alpha"); err != nil {
-		t.Fatalf("IndexDocument() error = %v", err)
-	}
-
-	var out bytes.Buffer
-	if err := <-svc.SaveSnapshotBufferedAsync(&out, indexCodecName, ""); err != nil {
-		t.Fatalf("SaveSnapshotBufferedAsync() error = %v", err)
-	}
-	if out.Len() == 0 {
-		t.Fatal("SaveSnapshotBufferedAsync() wrote empty payload")
+		t.Fatal("SaveSnapshot() wrote empty payload")
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -60,45 +60,7 @@ func main() {
 
 ### 3) Snapshots
 
-#### Simple file snapshot (index + filter in separate files)
-
-Use `pkg/ftsbuiltin` for built-in name-based codecs (`radix`, `bloom`, etc.) without manual codec registry wiring.
-
-For a more advanced in-memory `io.Writer`/`io.Reader` example with one combined payload, see `examples/client-library/snapshot-buffer-filter/main.go`.
-
-Save index + filter snapshots:
-
-```go
-package main
-
-import (
-	"context"
-	"os"
-
-	"github.com/dariasmyr/fts-engine/pkg/fts"
-	"github.com/dariasmyr/fts-engine/pkg/ftsbuiltin"
-	"github.com/dariasmyr/fts-engine/pkg/keygen"
-)
-
-func main() {
-	opts := ftsbuiltin.FilterOptions{BloomExpectedItems: 1_000_000, BloomBitsPerItem: 10, BloomK: 7}
-
-	idx, _ := ftsbuiltin.BuildIndex("radix")
-	flt, _ := ftsbuiltin.BuildFilter("bloom", opts)
-	svc := fts.New(idx, keygen.Word, fts.WithFilter(flt))
-	_ = svc.IndexDocument(context.Background(), "doc-1", "file snapshot demo")
-
-	indexOut, _ := os.Create("./data/segments/default.fidx")
-	defer indexOut.Close()
-	_ = ftsbuiltin.SaveIndexSnapshot(indexOut, "radix", idx)
-
-	filterOut, _ := os.Create("./data/segments/default.fflt")
-	defer filterOut.Close()
-	_ = ftsbuiltin.SaveFilterSnapshot(filterOut, "bloom", flt)
-}
-```
-
-Load snapshots from files:
+Recommended library flow is one combined snapshot payload with explicit codec registration.
 
 ```go
 package main
@@ -106,27 +68,45 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/dariasmyr/fts-engine/pkg/fts"
-	"github.com/dariasmyr/fts-engine/pkg/ftsbuiltin"
+	"github.com/dariasmyr/fts-engine/pkg/index/slicedradix"
 	"github.com/dariasmyr/fts-engine/pkg/keygen"
 )
 
+func init() {
+	_ = fts.RegisterIndexSnapshotCodec("slicedradix",
+		func(index fts.Index, w io.Writer) error {
+			s, ok := index.(fts.Serializable)
+			if !ok {
+				return fmt.Errorf("slicedradix: index does not implement Serializable")
+			}
+			return s.Serialize(w)
+		},
+		slicedradix.Load,
+	)
+}
+
 func main() {
-	indexIn, _ := os.Open("./data/segments/default.fidx")
-	defer indexIn.Close()
-	loadedIndex, _ := ftsbuiltin.LoadIndexSnapshot(indexIn)
+	svc := fts.New(slicedradix.New(), keygen.Word)
+	_ = svc.IndexDocument(context.Background(), "doc-1", "snapshot demo")
 
-	filterIn, _ := os.Open("./data/segments/default.fflt")
-	defer filterIn.Close()
-	loadedFilter, _ := ftsbuiltin.LoadFilterSnapshot(filterIn)
+	out, _ := os.Create("./data/segments/default.fidx")
+	defer out.Close()
+	_ = svc.SaveSnapshot(out, "slicedradix", "")
 
-	restored := fts.New(loadedIndex.Index, keygen.Word, fts.WithFilter(loadedFilter.Filter))
+	in, _ := os.Open("./data/segments/default.fidx")
+	defer in.Close()
+	restored, _ := fts.NewFromSnapshot(in, keygen.Word)
+
 	res, _ := restored.SearchDocuments(context.Background(), "snapshot", 10)
 	fmt.Println(res.TotalResultsCount)
 }
 ```
+
+If you prefer built-in name-based helpers (`radix`, `bloom`, `ribbon`, etc.), use `pkg/ftsbuiltin` examples in `examples/client-library/snapshot` and `examples/client-library/snapshot-buffer-filter`.
 
 ### 4) Custom pipeline and language presets
 
@@ -244,7 +224,7 @@ Snapshot fields (`fts.snapshot`):
 
 Ribbon is a static filter. In `fts` it is used via `BufferedStaticFilter`.
 
-Build ribbon from file with a custom parser:
+Preferred build API is stream-based (`BuildWithRetriesFromKeyStream`).
 
 ```go
 opts := ftsbuiltin.FilterOptions{
@@ -262,14 +242,26 @@ rf, _ := filter.NewRibbonFilter(
 	opts.RibbonSeed,
 )
 
-_ = rf.BuildWithRetriesFromFileWithParser("./data/keys.txt", parseKeysFile, opts.RibbonMaxAttempts)
+stream := func(emit func([]byte) bool) error {
+	keys := []string{"alpha", "hotel", "market"}
+	for _, key := range keys {
+		if !emit([]byte(key)) {
+			break
+		}
+	}
+	return nil
+}
+
+_ = rf.BuildWithRetriesFromKeyStream(stream, opts.RibbonMaxAttempts)
 
 out, _ := os.Create("./data/segments/ribbon.filter.fidx")
 defer out.Close()
 _ = rf.Serialize(out)
 ```
 
-Minimal parser example (line-by-line keys):
+If your keys come from files, add a thin adapter in client code that converts file parsing to stream emission.
+
+Minimal parser adapter example (line-by-line keys):
 
 ```go
 func parseKeysFile(path string, emit func([]byte) bool) error {


### PR DESCRIPTION
Drop deprecated wrapper methods in fts and ribbon APIs and switch tests/examples/docs to the stream-based and direct snapshot flows to keep the public surface minimal and consistent.