### PR TITLE
Add query diagnostics, observer stats, and bench observability

### DIFF
--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dariasmyr/fts-engine/pkg/fts"
 	"github.com/dariasmyr/fts-engine/pkg/ftsbuiltin"
 	"github.com/dariasmyr/fts-engine/pkg/ftspreset"
+	"github.com/dariasmyr/fts-engine/pkg/ftsstats"
 	"github.com/dariasmyr/fts-engine/pkg/keygen"
 )
 
@@ -32,6 +33,11 @@ func main() {
 		scorer      = flag.String("scorer", "simple", "ranking: simple | bm25 | tfidf")
 		bm25K1      = flag.Float64("bm25-k1", 1.2, "BM25 k1 parameter (only with -scorer=bm25)")
 		bm25B       = flag.Float64("bm25-b", 0.75, "BM25 b parameter (only with -scorer=bm25)")
+		diagnostics = flag.Bool("diagnostics", true, "enable per-query diagnostics collection during benchmark runs")
+		observer    = flag.Bool("observer", false, "enable search observer aggregation during benchmark runs")
+		repeat      = flag.Int("repeat", 1, "repeat the full query set N times for measured runs")
+		warmup      = flag.Int("warmup", 0, "run N warmup searches before measured runs (not included in metrics)")
+		shuffle     = flag.Bool("shuffle", false, "shuffle query order for warmup and each measured repeat using a fixed seed")
 	)
 	flag.Parse()
 
@@ -58,6 +64,11 @@ func main() {
 		scorer:      *scorer,
 		bm25K1:      *bm25K1,
 		bm25B:       *bm25B,
+		diagnostics: *diagnostics,
+		observer:    *observer,
+		repeat:      *repeat,
+		warmup:      *warmup,
+		shuffle:     *shuffle,
 	})
 	if err != nil {
 		log.Error("bench failed", "error", err)
@@ -78,6 +89,11 @@ type runOpts struct {
 	scorer      string
 	bm25K1      float64
 	bm25B       float64
+	diagnostics bool
+	observer    bool
+	repeat      int
+	warmup      int
+	shuffle     bool
 }
 
 func run(ctx context.Context, log *slog.Logger, o runOpts) error {
@@ -135,6 +151,12 @@ func run(ctx context.Context, log *slog.Logger, o runOpts) error {
 			log.Warn("ground truth has unresolved titles", "missing", missing, "note", "check spelling or increase -limit")
 		}
 	}
+	if o.repeat <= 0 {
+		return fmt.Errorf("repeat must be >= 1, got %d", o.repeat)
+	}
+	if o.warmup < 0 {
+		return fmt.Errorf("warmup must be >= 0, got %d", o.warmup)
+	}
 
 	idxReport, err := bench.IndexCorpus(ctx, svc, corpus, selector)
 	if err != nil {
@@ -142,14 +164,29 @@ func run(ctx context.Context, log *slog.Logger, o runOpts) error {
 	}
 	log.Info("indexing done", "documents", idxReport.DocumentCount, "duration", idxReport.Duration, "heap_mb", idxReport.HeapAllocMB)
 
-	queryReports, err := bench.RunQueries(ctx, svc, gt, titleIdx, o.k)
+	var observerStats *ftsstats.SearchStats
+	if o.observer {
+		observerStats = ftsstats.NewSearchStats(64)
+	}
+
+	queryReports, err := bench.RunQueries(ctx, svc, gt, titleIdx, o.k, bench.RunQueryOptions{
+		Diagnostics: o.diagnostics,
+		Observer:    observerStats,
+		Repeat:      o.repeat,
+		Warmup:      o.warmup,
+		Shuffle:     o.shuffle,
+	})
 	if err != nil {
 		return fmt.Errorf("run queries: %w", err)
 	}
 
-	report := bench.Aggregate(o.k, idxReport, queryReports)
-	fmt.Fprintf(os.Stdout, "\n=== bench result: index=%s lang=%s field=%s scorer=%s ===\n", o.indexKind, o.lang, o.field, o.scorer)
+	report := bench.Aggregate(o.k, idxReport, queryReports, o.diagnostics)
+	fmt.Fprintf(os.Stdout, "\n=== bench result: index=%s lang=%s field=%s scorer=%s diagnostics=%t observer=%t repeat=%d warmup=%d shuffle=%t ===\n", o.indexKind, o.lang, o.field, o.scorer, o.diagnostics, o.observer, o.repeat, o.warmup, o.shuffle)
 	bench.WriteReport(os.Stdout, report, o.worst)
+	if observerStats != nil {
+		snap := observerStats.Snapshot()
+		fmt.Fprintf(os.Stdout, "\nObserver: total=%d errors=%d zero_results=%d strategies=%d\n", snap.TotalSearches, snap.ErrorsTotal, snap.ZeroResults, len(snap.ByStrategy))
+	}
 	return nil
 }
 

--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -28,7 +28,7 @@ func main() {
 		field       = flag.String("field", "abstract", "document field to index: abstract | extract | title")
 		k           = flag.Int("k", 10, "top-k used for nDCG and Recall")
 		limit       = flag.Int("limit", 0, "cap documents indexed (0 = all)")
-		worst       = flag.Int("worst", 5, "print N worst queries by nDCG (0 = none)")
+		worst       = flag.Int("worst", 5, "print N worst queries by nDCG and postings_read (0 = none)")
 		warnMissing = flag.Bool("warn-missing", true, "warn if ground-truth titles don't resolve in the corpus")
 		scorer      = flag.String("scorer", "simple", "ranking: simple | bm25 | tfidf")
 		bm25K1      = flag.Float64("bm25-k1", 1.2, "BM25 k1 parameter (only with -scorer=bm25)")

--- a/cmd/fts/main.go
+++ b/cmd/fts/main.go
@@ -268,7 +268,7 @@ func (s *serviceAdapter) SearchDocuments(ctx context.Context, query string, maxR
 	return &models.SearchResult{
 		ResultData:        out,
 		TotalResultsCount: result.TotalResultsCount,
-		Timings:           formatDiagnosticsTimings(result.Diagnostics),
+		Diagnostics:       projectDiagnostics(result.Diagnostics),
 	}, nil
 }
 
@@ -310,6 +310,28 @@ func formatDiagnosticsTimings(diag *pkgfts.QueryDiagnostics) map[string]string {
 		out[key] = formatAppDuration(d)
 	}
 	return out
+}
+
+func projectDiagnostics(diag *pkgfts.QueryDiagnostics) *models.SearchDiagnostics {
+	if diag == nil {
+		return nil
+	}
+	return &models.SearchDiagnostics{
+		LogicalQueryType:   diag.LogicalQueryType,
+		ExecutionStrategy:  diag.ExecutionStrategy,
+		StrategySkipReason: diag.StrategySkipReason,
+		Timings:            formatDiagnosticsTimings(diag),
+		ProcessedTokens:    diag.ProcessedTokens,
+		FieldsVisited:      diag.FieldsVisited,
+		GeneratedKeys:      diag.GeneratedKeys,
+		IndexSearches:      diag.IndexSearches,
+		FilterChecks:       diag.FilterChecks,
+		FilterRejects:      diag.FilterRejects,
+		PostingEntriesRead: diag.PostingEntriesRead,
+		CandidateDocs:      diag.CandidateDocs,
+		MatchedDocs:        diag.MatchedDocs,
+		ReturnedDocs:       diag.ReturnedDocs,
+	}
 }
 
 func formatAppDuration(d time.Duration) string {

--- a/cmd/fts/main.go
+++ b/cmd/fts/main.go
@@ -268,7 +268,7 @@ func (s *serviceAdapter) SearchDocuments(ctx context.Context, query string, maxR
 	return &models.SearchResult{
 		ResultData:        out,
 		TotalResultsCount: result.TotalResultsCount,
-		Timings:           result.Timings,
+		Timings:           formatDiagnosticsTimings(result.Diagnostics),
 	}, nil
 }
 
@@ -299,6 +299,24 @@ func logSearchStats(log *slog.Logger, snapshot ftsstats.Snapshot) {
 			"avg_postings", stats.AvgPostings(),
 		)
 	}
+}
+
+func formatDiagnosticsTimings(diag *pkgfts.QueryDiagnostics) map[string]string {
+	if diag == nil || len(diag.Timings) == 0 {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(diag.Timings))
+	for key, d := range diag.Timings {
+		out[key] = formatAppDuration(d)
+	}
+	return out
+}
+
+func formatAppDuration(d time.Duration) string {
+	if d < time.Millisecond {
+		return fmt.Sprintf("%dus", d.Microseconds())
+	}
+	return fmt.Sprintf("%dms", d.Milliseconds())
 }
 
 func buildService(log *slog.Logger, cfg *config.Config, keyGen pkgfts.KeyGenerator, pipeline textproc.Pipeline) (*pkgfts.Service, bool, error) {

--- a/cmd/fts/main.go
+++ b/cmd/fts/main.go
@@ -244,13 +244,10 @@ func (s *serviceAdapter) IndexDocument(ctx context.Context, docID string, conten
 }
 
 func (s *serviceAdapter) SearchDocuments(ctx context.Context, query string, maxResults int) (*models.SearchResult, error) {
+	ctx = pkgfts.WithDiagnostics(ctx)
 	result, err := s.service.SearchDocuments(ctx, query, maxResults)
 	if s.searchStats != nil {
-		var diag *pkgfts.QueryDiagnostics
-		if result != nil {
-			diag = result.Diagnostics
-		}
-		s.searchStats.ObserveSearch(query, diag, err)
+		s.searchStats.ObserveResult(query, result, err)
 	}
 	if err != nil {
 		return nil, err

--- a/cmd/fts/main.go
+++ b/cmd/fts/main.go
@@ -20,11 +20,11 @@ import (
 	"github.com/dariasmyr/fts-engine/config"
 	"github.com/dariasmyr/fts-engine/internal/adapters/cui"
 	"github.com/dariasmyr/fts-engine/internal/adapters/loader/wiki"
-	"github.com/dariasmyr/fts-engine/internal/adapters/observability"
 	"github.com/dariasmyr/fts-engine/internal/domain/models"
 	"github.com/dariasmyr/fts-engine/internal/lib/logger/sl"
 	pkgfts "github.com/dariasmyr/fts-engine/pkg/fts"
 	"github.com/dariasmyr/fts-engine/pkg/ftsbuiltin"
+	"github.com/dariasmyr/fts-engine/pkg/ftsstats"
 	"github.com/dariasmyr/fts-engine/pkg/keygen"
 	"github.com/dariasmyr/fts-engine/pkg/textproc"
 )
@@ -101,7 +101,7 @@ func main() {
 			log.Error("Failed to initialize trie service", "error", sl.Err(err))
 			return
 		}
-		ftsEngine = &serviceAdapter{service: svc, snapshotLoaded: loadedFromSnapshot, searchStats: observability.NewSearchStats(64)}
+		ftsEngine = &serviceAdapter{service: svc, snapshotLoaded: loadedFromSnapshot, searchStats: ftsstats.NewSearchStats(64)}
 	default:
 		log.Error("unknown fts engine", "engine", cfg.FTS.Engine)
 		return
@@ -236,7 +236,7 @@ func analyzeTrie(
 type serviceAdapter struct {
 	service        *pkgfts.Service
 	snapshotLoaded bool
-	searchStats    *observability.SearchStats
+	searchStats    *ftsstats.SearchStats
 }
 
 func (s *serviceAdapter) IndexDocument(ctx context.Context, docID string, content string) error {
@@ -276,14 +276,14 @@ func (s *serviceAdapter) AnalyzeStats() (pkgfts.Stats, bool) {
 	return s.service.Analyze()
 }
 
-func (s *serviceAdapter) SearchStatsSnapshot() (observability.Snapshot, bool) {
+func (s *serviceAdapter) SearchStatsSnapshot() (ftsstats.Snapshot, bool) {
 	if s.searchStats == nil {
-		return observability.Snapshot{}, false
+		return ftsstats.Snapshot{}, false
 	}
 	return s.searchStats.Snapshot(), true
 }
 
-func logSearchStats(log *slog.Logger, snapshot observability.Snapshot) {
+func logSearchStats(log *slog.Logger, snapshot ftsstats.Snapshot) {
 	log.Info("search diagnostics summary",
 		"total_searches", snapshot.TotalSearches,
 		"errors_total", snapshot.ErrorsTotal,

--- a/cmd/fts/main.go
+++ b/cmd/fts/main.go
@@ -302,12 +302,18 @@ func logSearchStats(log *slog.Logger, snapshot ftsstats.Snapshot) {
 }
 
 func formatDiagnosticsTimings(diag *pkgfts.QueryDiagnostics) map[string]string {
-	if diag == nil || len(diag.Timings) == 0 {
+	if diag == nil {
 		return map[string]string{}
 	}
-	out := make(map[string]string, len(diag.Timings))
-	for key, d := range diag.Timings {
-		out[key] = formatAppDuration(d)
+	out := make(map[string]string, 3)
+	if diag.Timings.HasPreprocess() {
+		out["preprocess"] = formatAppDuration(diag.Timings.Preprocess)
+	}
+	if diag.Timings.HasSearchTokens() {
+		out["search_tokens"] = formatAppDuration(diag.Timings.SearchTokens)
+	}
+	if diag.Timings.HasTotal() {
+		out["total"] = formatAppDuration(diag.Timings.Total)
 	}
 	return out
 }

--- a/cmd/fts/main.go
+++ b/cmd/fts/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/dariasmyr/fts-engine/config"
 	"github.com/dariasmyr/fts-engine/internal/adapters/cui"
 	"github.com/dariasmyr/fts-engine/internal/adapters/loader/wiki"
+	"github.com/dariasmyr/fts-engine/internal/adapters/observability"
 	"github.com/dariasmyr/fts-engine/internal/domain/models"
 	"github.com/dariasmyr/fts-engine/internal/lib/logger/sl"
 	pkgfts "github.com/dariasmyr/fts-engine/pkg/fts"
@@ -100,7 +101,7 @@ func main() {
 			log.Error("Failed to initialize trie service", "error", sl.Err(err))
 			return
 		}
-		ftsEngine = &serviceAdapter{service: svc, snapshotLoaded: loadedFromSnapshot}
+		ftsEngine = &serviceAdapter{service: svc, snapshotLoaded: loadedFromSnapshot, searchStats: observability.NewSearchStats(64)}
 	default:
 		log.Error("unknown fts engine", "engine", cfg.FTS.Engine)
 		return
@@ -187,6 +188,9 @@ func main() {
 		log.Error("Failed to start appCUI", "error", sl.Err(cuiErr))
 		return
 	}
+	if snapshot, ok := adapter.SearchStatsSnapshot(); ok && snapshot.TotalSearches > 0 {
+		logSearchStats(log, snapshot)
+	}
 }
 
 func analyzeTrie(
@@ -232,6 +236,7 @@ func analyzeTrie(
 type serviceAdapter struct {
 	service        *pkgfts.Service
 	snapshotLoaded bool
+	searchStats    *observability.SearchStats
 }
 
 func (s *serviceAdapter) IndexDocument(ctx context.Context, docID string, content string) error {
@@ -240,6 +245,13 @@ func (s *serviceAdapter) IndexDocument(ctx context.Context, docID string, conten
 
 func (s *serviceAdapter) SearchDocuments(ctx context.Context, query string, maxResults int) (*models.SearchResult, error) {
 	result, err := s.service.SearchDocuments(ctx, query, maxResults)
+	if s.searchStats != nil {
+		var diag *pkgfts.QueryDiagnostics
+		if result != nil {
+			diag = result.Diagnostics
+		}
+		s.searchStats.ObserveSearch(query, diag, err)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -262,6 +274,31 @@ func (s *serviceAdapter) SearchDocuments(ctx context.Context, query string, maxR
 
 func (s *serviceAdapter) AnalyzeStats() (pkgfts.Stats, bool) {
 	return s.service.Analyze()
+}
+
+func (s *serviceAdapter) SearchStatsSnapshot() (observability.Snapshot, bool) {
+	if s.searchStats == nil {
+		return observability.Snapshot{}, false
+	}
+	return s.searchStats.Snapshot(), true
+}
+
+func logSearchStats(log *slog.Logger, snapshot observability.Snapshot) {
+	log.Info("search diagnostics summary",
+		"total_searches", snapshot.TotalSearches,
+		"errors_total", snapshot.ErrorsTotal,
+		"zero_results", snapshot.ZeroResults,
+		"strategies", len(snapshot.ByStrategy),
+	)
+	for strategy, stats := range snapshot.ByStrategy {
+		log.Info("search diagnostics strategy",
+			"strategy", strategy,
+			"count", stats.Count,
+			"avg_duration", stats.AvgDuration(),
+			"max_duration", stats.MaxDuration,
+			"avg_postings", stats.AvgPostings(),
+		)
+	}
 }
 
 func buildService(log *slog.Logger, cfg *config.Config, keyGen pkgfts.KeyGenerator, pipeline textproc.Pipeline) (*pkgfts.Service, bool, error) {

--- a/cmd/fts/main_test.go
+++ b/cmd/fts/main_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/dariasmyr/fts-engine/internal/adapters/observability"
 	"github.com/dariasmyr/fts-engine/pkg/fts"
+	"github.com/dariasmyr/fts-engine/pkg/ftsstats"
 	"github.com/dariasmyr/fts-engine/pkg/index/radix"
 )
 
@@ -19,7 +19,7 @@ func TestServiceAdapterObservesSearchDiagnostics(t *testing.T) {
 		t.Fatalf("IndexDocument() error = %v", err)
 	}
 
-	adapter := &serviceAdapter{service: svc, searchStats: observability.NewSearchStats(8)}
+	adapter := &serviceAdapter{service: svc, searchStats: ftsstats.NewSearchStats(8)}
 	if _, err := adapter.SearchDocuments(ctx, "alpha", 10); err != nil {
 		t.Fatalf("SearchDocuments() error = %v", err)
 	}

--- a/cmd/fts/main_test.go
+++ b/cmd/fts/main_test.go
@@ -20,8 +20,18 @@ func TestServiceAdapterObservesSearchDiagnostics(t *testing.T) {
 	}
 
 	adapter := &serviceAdapter{service: svc, searchStats: ftsstats.NewSearchStats(8)}
-	if _, err := adapter.SearchDocuments(ctx, "alpha", 10); err != nil {
+	res, err := adapter.SearchDocuments(ctx, "alpha", 10)
+	if err != nil {
 		t.Fatalf("SearchDocuments() error = %v", err)
+	}
+	if res.Diagnostics == nil {
+		t.Fatal("expected projected diagnostics in models.SearchResult")
+	}
+	if res.Diagnostics.ExecutionStrategy == "" {
+		t.Fatalf("expected execution strategy, got %+v", res.Diagnostics)
+	}
+	if res.Diagnostics.Timings["total"] == "" {
+		t.Fatalf("expected formatted total timing, got %+v", res.Diagnostics.Timings)
 	}
 
 	snap, ok := adapter.SearchStatsSnapshot()

--- a/cmd/fts/main_test.go
+++ b/cmd/fts/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dariasmyr/fts-engine/internal/adapters/observability"
+	"github.com/dariasmyr/fts-engine/pkg/fts"
+	"github.com/dariasmyr/fts-engine/pkg/index/radix"
+)
+
+func TestServiceAdapterObservesSearchDiagnostics(t *testing.T) {
+	svc := fts.New(radix.New(), fts.WordKeys)
+	ctx := context.Background()
+	if err := svc.IndexDocument(ctx, "doc-1", "alpha beta gamma"); err != nil {
+		t.Fatalf("IndexDocument() error = %v", err)
+	}
+	if err := svc.IndexDocument(ctx, "doc-2", "alpha delta"); err != nil {
+		t.Fatalf("IndexDocument() error = %v", err)
+	}
+
+	adapter := &serviceAdapter{service: svc, searchStats: observability.NewSearchStats(8)}
+	if _, err := adapter.SearchDocuments(ctx, "alpha", 10); err != nil {
+		t.Fatalf("SearchDocuments() error = %v", err)
+	}
+
+	snap, ok := adapter.SearchStatsSnapshot()
+	if !ok {
+		t.Fatal("expected SearchStatsSnapshot to be available")
+	}
+	if snap.TotalSearches != 1 {
+		t.Fatalf("TotalSearches = %d, want 1", snap.TotalSearches)
+	}
+	if len(snap.ByStrategy) == 0 {
+		t.Fatalf("expected strategy aggregation, got %+v", snap.ByStrategy)
+	}
+	if len(snap.Recent) != 1 || snap.Recent[0].ExecutionStrategy == "" || snap.Recent[0].TotalDuration <= 0 {
+		t.Fatalf("unexpected recent event: %+v", snap.Recent)
+	}
+}

--- a/internal/adapters/cui/cui.go
+++ b/internal/adapters/cui/cui.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -185,7 +186,7 @@ func (c *CUI) layout(g *gocui.Gui) error {
 func (c *CUI) search(g *gocui.Gui, v *gocui.View, ctx context.Context, searchQuery string) error {
 	searchQuery = strings.TrimSpace(v.Buffer())
 
-	results, elapsedTime, totalResultsCount, err := c.performSearch(searchQuery, ctx)
+	results, diagnostics, totalResultsCount, err := c.performSearch(searchQuery, ctx)
 
 	timeView, err := g.View("time")
 	if err != nil {
@@ -193,10 +194,39 @@ func (c *CUI) search(g *gocui.Gui, v *gocui.View, ctx context.Context, searchQue
 	}
 	timeView.Clear()
 
-	fmt.Fprintln(timeView, "\033[33mSearch Time:\033[0m")
-
-	for phase, duration := range elapsedTime {
-		fmt.Fprintf(timeView, "\033[32m%s: %s\033[0m\n", phase, duration)
+	fmt.Fprintln(timeView, "\033[33mSearch Diagnostics:\033[0m")
+	if diagnostics != nil {
+		fmt.Fprintf(timeView, "\033[32mquery_type: %s\033[0m\n", diagnostics.LogicalQueryType)
+		fmt.Fprintf(timeView, "\033[32mstrategy: %s\033[0m\n", diagnostics.ExecutionStrategy)
+		if diagnostics.StrategySkipReason != "" {
+			fmt.Fprintf(timeView, "\033[32mskip_reason: %s\033[0m\n", diagnostics.StrategySkipReason)
+		}
+		for _, phase := range []string{"preprocess", "search_tokens", "total"} {
+			if duration, ok := diagnostics.Timings[phase]; ok {
+				fmt.Fprintf(timeView, "\033[32m%s: %s\033[0m\n", phase, duration)
+			}
+		}
+		extraTimingKeys := make([]string, 0, len(diagnostics.Timings))
+		for phase := range diagnostics.Timings {
+			if phase == "preprocess" || phase == "search_tokens" || phase == "total" {
+				continue
+			}
+			extraTimingKeys = append(extraTimingKeys, phase)
+		}
+		sort.Strings(extraTimingKeys)
+		for _, phase := range extraTimingKeys {
+			fmt.Fprintf(timeView, "\033[32m%s: %s\033[0m\n", phase, diagnostics.Timings[phase])
+		}
+		fmt.Fprintf(timeView, "\033[32mprocessed_tokens: %d\033[0m\n", diagnostics.ProcessedTokens)
+		fmt.Fprintf(timeView, "\033[32mfields_visited: %d\033[0m\n", diagnostics.FieldsVisited)
+		fmt.Fprintf(timeView, "\033[32mgenerated_keys: %d\033[0m\n", diagnostics.GeneratedKeys)
+		fmt.Fprintf(timeView, "\033[32mindex_searches: %d\033[0m\n", diagnostics.IndexSearches)
+		fmt.Fprintf(timeView, "\033[32mfilter_checks: %d\033[0m\n", diagnostics.FilterChecks)
+		fmt.Fprintf(timeView, "\033[32mfilter_rejects: %d\033[0m\n", diagnostics.FilterRejects)
+		fmt.Fprintf(timeView, "\033[32mpostings_read: %d\033[0m\n", diagnostics.PostingEntriesRead)
+		fmt.Fprintf(timeView, "\033[32mcandidate_docs: %d\033[0m\n", diagnostics.CandidateDocs)
+		fmt.Fprintf(timeView, "\033[32mmatched_docs: %d\033[0m\n", diagnostics.MatchedDocs)
+		fmt.Fprintf(timeView, "\033[32mreturned_docs: %d\033[0m\n", diagnostics.ReturnedDocs)
 	}
 
 	outputView, err := g.View("output")
@@ -232,7 +262,7 @@ func highlightQueryInResult(document *models.Document, query string) {
 	}
 }
 
-func (c *CUI) performSearch(query string, ctx context.Context) ([]models.ResultData, map[string]string, int, error) {
+func (c *CUI) performSearch(query string, ctx context.Context) ([]models.ResultData, *models.SearchDiagnostics, int, error) {
 	searchResult, err := c.ftsService.SearchDocuments(
 		ctx,
 		query,
@@ -251,7 +281,7 @@ func (c *CUI) performSearch(query string, ctx context.Context) ([]models.ResultD
 	if err != nil {
 		return nil, nil, 0, err
 	}
-	return searchResult.ResultData, searchResult.Timings, searchResult.TotalResultsCount, nil
+	return searchResult.ResultData, searchResult.Diagnostics, searchResult.TotalResultsCount, nil
 }
 
 func quit(g *gocui.Gui, v *gocui.View) error {

--- a/internal/adapters/observability/search_stats.go
+++ b/internal/adapters/observability/search_stats.go
@@ -1,0 +1,203 @@
+package observability
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+	"time"
+
+	"github.com/dariasmyr/fts-engine/pkg/fts"
+)
+
+const defaultRecentLimit = 64
+
+type SearchStats struct {
+	mu sync.Mutex
+
+	totalSearches int
+	errorsTotal   int
+	zeroResults   int
+	byStrategy    map[string]StrategyStats
+	recent        ringBuffer
+}
+
+type StrategyStats struct {
+	Count              int
+	CumulativeDuration time.Duration
+	TotalPostings      int
+	MaxDuration        time.Duration
+}
+
+func (s StrategyStats) AvgDuration() time.Duration {
+	if s.Count == 0 {
+		return 0
+	}
+	return s.CumulativeDuration / time.Duration(s.Count)
+}
+
+func (s StrategyStats) AvgPostings() float64 {
+	if s.Count == 0 {
+		return 0
+	}
+	return float64(s.TotalPostings) / float64(s.Count)
+}
+
+type SearchEvent struct {
+	At                 time.Time
+	QueryHash          string
+	LogicalQueryType   string
+	ExecutionStrategy  string
+	StrategySkipReason string
+	TotalDuration      time.Duration
+	PostingEntriesRead int
+	MatchedDocs        int
+	ReturnedDocs       int
+	Error              string
+}
+
+type Snapshot struct {
+	TotalSearches int
+	ErrorsTotal   int
+	ZeroResults   int
+	ByStrategy    map[string]StrategyStats
+	Recent        []SearchEvent
+}
+
+func NewSearchStats(recentLimit int) *SearchStats {
+	if recentLimit <= 0 {
+		recentLimit = defaultRecentLimit
+	}
+	return &SearchStats{
+		byStrategy: make(map[string]StrategyStats),
+		recent:     newRingBuffer(recentLimit),
+	}
+}
+
+func (s *SearchStats) ObserveSearch(query string, d *fts.QueryDiagnostics, err error) {
+	if s == nil {
+		return
+	}
+
+	event := SearchEvent{At: time.Now(), QueryHash: queryHash(query)}
+	if d != nil {
+		event.LogicalQueryType = d.LogicalQueryType
+		event.ExecutionStrategy = d.ExecutionStrategy
+		event.StrategySkipReason = d.StrategySkipReason
+		event.TotalDuration = d.Timings["total"]
+		event.PostingEntriesRead = d.PostingEntriesRead
+		event.MatchedDocs = d.MatchedDocs
+		event.ReturnedDocs = d.ReturnedDocs
+	}
+	if err != nil {
+		event.Error = err.Error()
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.totalSearches++
+	if err != nil {
+		s.errorsTotal++
+	}
+	if d != nil && d.MatchedDocs == 0 {
+		s.zeroResults++
+	}
+	if d != nil {
+		strategy := d.ExecutionStrategy
+		if strategy == "" {
+			strategy = "unknown"
+		}
+		st := s.byStrategy[strategy]
+		st.Count++
+		st.CumulativeDuration += d.Timings["total"]
+		st.TotalPostings += d.PostingEntriesRead
+		if d.Timings["total"] > st.MaxDuration {
+			st.MaxDuration = d.Timings["total"]
+		}
+		s.byStrategy[strategy] = st
+	}
+	s.recent.add(event)
+}
+
+func (s *SearchStats) Snapshot() Snapshot {
+	if s == nil {
+		return Snapshot{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := Snapshot{
+		TotalSearches: s.totalSearches,
+		ErrorsTotal:   s.errorsTotal,
+		ZeroResults:   s.zeroResults,
+		ByStrategy:    make(map[string]StrategyStats, len(s.byStrategy)),
+		Recent:        s.recent.snapshot(0),
+	}
+	for k, v := range s.byStrategy {
+		out.ByStrategy[k] = v
+	}
+	return out
+}
+
+func (s *SearchStats) Recent(limit int) []SearchEvent {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.recent.snapshot(limit)
+}
+
+func queryHash(query string) string {
+	if query == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(query))
+	return hex.EncodeToString(sum[:8])
+}
+
+type ringBuffer struct {
+	items  []SearchEvent
+	next   int
+	filled bool
+}
+
+func newRingBuffer(size int) ringBuffer {
+	if size <= 0 {
+		size = defaultRecentLimit
+	}
+	return ringBuffer{items: make([]SearchEvent, size)}
+}
+
+func (r *ringBuffer) add(ev SearchEvent) {
+	if len(r.items) == 0 {
+		return
+	}
+	r.items[r.next] = ev
+	r.next = (r.next + 1) % len(r.items)
+	if r.next == 0 {
+		r.filled = true
+	}
+}
+
+func (r *ringBuffer) snapshot(limit int) []SearchEvent {
+	size := r.size()
+	if size == 0 {
+		return nil
+	}
+	if limit <= 0 || limit > size {
+		limit = size
+	}
+	out := make([]SearchEvent, 0, limit)
+	for i := 0; i < limit; i++ {
+		idx := (r.next - 1 - i + len(r.items)) % len(r.items)
+		out = append(out, r.items[idx])
+	}
+	return out
+}
+
+func (r *ringBuffer) size() int {
+	if r.filled {
+		return len(r.items)
+	}
+	return r.next
+}

--- a/internal/adapters/observability/search_stats_test.go
+++ b/internal/adapters/observability/search_stats_test.go
@@ -1,0 +1,90 @@
+package observability
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dariasmyr/fts-engine/pkg/fts"
+)
+
+func TestSearchStatsObserveAggregatesByStrategy(t *testing.T) {
+	stats := NewSearchStats(4)
+	stats.ObserveSearch("alpha beta", &fts.QueryDiagnostics{
+		LogicalQueryType:   "boolean",
+		ExecutionStrategy:  "bool_or_wand",
+		StrategySkipReason: "and_fast_no_must_terms",
+		PostingEntriesRead: 12,
+		MatchedDocs:        3,
+		ReturnedDocs:       2,
+		Timings:            map[string]time.Duration{"total": 8 * time.Millisecond},
+	}, nil)
+	stats.ObserveSearch("alpha", &fts.QueryDiagnostics{
+		LogicalQueryType:   "term",
+		ExecutionStrategy:  "term",
+		PostingEntriesRead: 4,
+		MatchedDocs:        0,
+		ReturnedDocs:       0,
+		Timings:            map[string]time.Duration{"total": 2 * time.Millisecond},
+	}, nil)
+
+	snap := stats.Snapshot()
+	if snap.TotalSearches != 2 {
+		t.Fatalf("TotalSearches = %d, want 2", snap.TotalSearches)
+	}
+	if snap.ZeroResults != 1 {
+		t.Fatalf("ZeroResults = %d, want 1", snap.ZeroResults)
+	}
+	if got := snap.ByStrategy["bool_or_wand"]; got.Count != 1 || got.TotalPostings != 12 || got.CumulativeDuration != 8*time.Millisecond {
+		t.Fatalf("bool_or_wand stats = %+v, want count=1 postings=12 duration=8ms", got)
+	}
+	if got := snap.ByStrategy["bool_or_wand"].AvgDuration(); got != 8*time.Millisecond {
+		t.Fatalf("AvgDuration = %v, want 8ms", got)
+	}
+	if got := snap.ByStrategy["bool_or_wand"].AvgPostings(); got != 12 {
+		t.Fatalf("AvgPostings = %v, want 12", got)
+	}
+	if len(snap.Recent) != 2 {
+		t.Fatalf("Recent len = %d, want 2", len(snap.Recent))
+	}
+	if snap.Recent[0].LogicalQueryType != "term" || snap.Recent[1].LogicalQueryType != "boolean" {
+		t.Fatalf("unexpected recent order: %+v", snap.Recent)
+	}
+	if snap.Recent[1].StrategySkipReason != "and_fast_no_must_terms" {
+		t.Fatalf("StrategySkipReason = %q, want and_fast_no_must_terms", snap.Recent[1].StrategySkipReason)
+	}
+	if snap.Recent[1].QueryHash == "" || snap.Recent[1].QueryHash == "alpha beta" {
+		t.Fatalf("expected hashed query, got %q", snap.Recent[1].QueryHash)
+	}
+}
+
+func TestSearchStatsObserveErrorWithoutDiagnostics(t *testing.T) {
+	stats := NewSearchStats(2)
+	stats.ObserveSearch("broken", nil, errors.New("boom"))
+
+	snap := stats.Snapshot()
+	if snap.TotalSearches != 1 || snap.ErrorsTotal != 1 {
+		t.Fatalf("unexpected snapshot totals: %+v", snap)
+	}
+	if len(snap.ByStrategy) != 0 {
+		t.Fatalf("ByStrategy = %+v, want empty", snap.ByStrategy)
+	}
+	if len(snap.Recent) != 1 || snap.Recent[0].Error != "boom" {
+		t.Fatalf("unexpected recent events: %+v", snap.Recent)
+	}
+}
+
+func TestSearchStatsRecentLimit(t *testing.T) {
+	stats := NewSearchStats(2)
+	stats.ObserveSearch("one", &fts.QueryDiagnostics{Timings: map[string]time.Duration{}}, nil)
+	stats.ObserveSearch("two", &fts.QueryDiagnostics{Timings: map[string]time.Duration{}}, nil)
+	stats.ObserveSearch("three", &fts.QueryDiagnostics{Timings: map[string]time.Duration{}}, nil)
+
+	recent := stats.Recent(2)
+	if len(recent) != 2 {
+		t.Fatalf("Recent len = %d, want 2", len(recent))
+	}
+	if recent[0].QueryHash != queryHash("three") || recent[1].QueryHash != queryHash("two") {
+		t.Fatalf("unexpected recent order: %+v", recent)
+	}
+}

--- a/internal/bench/harness.go
+++ b/internal/bench/harness.go
@@ -173,8 +173,8 @@ func RunQueries(ctx context.Context, svc *pkgfts.Service, gt *GroundTruth, title
 			queryReport.StrategySkipReason = diag.StrategySkipReason
 			queryReport.IndexSearches = diag.IndexSearches
 			queryReport.PostingEntriesRead = diag.PostingEntriesRead
-			queryReport.DiagnosticsTotal = diag.Timings["total"]
-			queryReport.DiagnosticsSearchTokens = diag.Timings["search_tokens"]
+			queryReport.DiagnosticsTotal = diag.Timings.Total
+			queryReport.DiagnosticsSearchTokens = diag.Timings.SearchTokens
 		}
 
 		reports = append(reports, queryReport)

--- a/internal/bench/harness.go
+++ b/internal/bench/harness.go
@@ -48,7 +48,7 @@ type QueryReport struct {
 	Recall                  float64
 	Latency                 time.Duration
 	ExecutionStrategy       string
-	StrategyReason          string
+	StrategySkipReason      string
 	IndexSearches           int
 	PostingEntriesRead      int
 	DiagnosticsTotal        time.Duration
@@ -170,7 +170,7 @@ func RunQueries(ctx context.Context, svc *pkgfts.Service, gt *GroundTruth, title
 		}
 		if diag := res.Diagnostics; diag != nil {
 			queryReport.ExecutionStrategy = diag.ExecutionStrategy
-			queryReport.StrategyReason = diag.StrategyReason
+			queryReport.StrategySkipReason = diag.StrategySkipReason
 			queryReport.IndexSearches = diag.IndexSearches
 			queryReport.PostingEntriesRead = diag.PostingEntriesRead
 			queryReport.DiagnosticsTotal = diag.Timings["total"]

--- a/internal/bench/harness.go
+++ b/internal/bench/harness.go
@@ -40,25 +40,48 @@ type IndexReport struct {
 }
 
 type QueryReport struct {
-	Query    string
-	Returned int
-	Relevant int
-	NDCG     float64
-	MRR      float64
-	Recall   float64
-	Latency  time.Duration
+	Query                   string
+	Returned                int
+	Relevant                int
+	NDCG                    float64
+	MRR                     float64
+	Recall                  float64
+	Latency                 time.Duration
+	ExecutionStrategy       string
+	StrategyReason          string
+	IndexSearches           int
+	PostingEntriesRead      int
+	DiagnosticsTotal        time.Duration
+	DiagnosticsSearchTokens time.Duration
+}
+
+type StrategyReport struct {
+	Count             int
+	TotalDuration     time.Duration
+	TotalSearchTokens time.Duration
+	TotalPostingsRead int
+	TotalIndexSearch  int
 }
 
 type Report struct {
-	K          int
-	Index      IndexReport
-	Queries    []QueryReport
-	LatencyP50 time.Duration
-	LatencyP95 time.Duration
-	LatencyP99 time.Duration
-	MeanNDCG   float64
-	MeanMRR    float64
-	MeanRecall float64
+	K                      int
+	Index                  IndexReport
+	Queries                []QueryReport
+	LatencyP50             time.Duration
+	LatencyP95             time.Duration
+	LatencyP99             time.Duration
+	DiagnosticsTotalP50    time.Duration
+	DiagnosticsTotalP95    time.Duration
+	DiagnosticsTotalP99    time.Duration
+	DiagnosticsSearchP50   time.Duration
+	DiagnosticsSearchP95   time.Duration
+	DiagnosticsSearchP99   time.Duration
+	MeanNDCG               float64
+	MeanMRR                float64
+	MeanRecall             float64
+	MeanPostingEntriesRead float64
+	MeanIndexSearches      float64
+	Strategies             map[string]StrategyReport
 }
 
 func IndexCorpus(ctx context.Context, svc *pkgfts.Service, corpus Corpus, content ContentSelector) (IndexReport, error) {
@@ -136,7 +159,7 @@ func RunQueries(ctx context.Context, svc *pkgfts.Service, gt *GroundTruth, title
 			ranked = append(ranked, string(item.ID))
 		}
 
-		reports = append(reports, QueryReport{
+		queryReport := QueryReport{
 			Query:    q.Query,
 			Returned: len(ranked),
 			Relevant: relevant.Size(),
@@ -144,33 +167,70 @@ func RunQueries(ctx context.Context, svc *pkgfts.Service, gt *GroundTruth, title
 			MRR:      MRR(ranked, relevant),
 			Recall:   Recall(ranked, relevant, k),
 			Latency:  elapsed,
-		})
+		}
+		if diag := res.Diagnostics; diag != nil {
+			queryReport.ExecutionStrategy = diag.ExecutionStrategy
+			queryReport.StrategyReason = diag.StrategyReason
+			queryReport.IndexSearches = diag.IndexSearches
+			queryReport.PostingEntriesRead = diag.PostingEntriesRead
+			queryReport.DiagnosticsTotal = diag.Timings["total"]
+			queryReport.DiagnosticsSearchTokens = diag.Timings["search_tokens"]
+		}
+
+		reports = append(reports, queryReport)
 	}
 	return reports, nil
 }
 
 func Aggregate(k int, idx IndexReport, queries []QueryReport) Report {
-	report := Report{K: k, Index: idx, Queries: queries}
+	report := Report{K: k, Index: idx, Queries: queries, Strategies: make(map[string]StrategyReport)}
 	if len(queries) == 0 {
 		return report
 	}
 
 	latencies := make([]time.Duration, 0, len(queries))
+	diagnosticsTotals := make([]time.Duration, 0, len(queries))
+	searchTimings := make([]time.Duration, 0, len(queries))
 	var sumNDCG, sumMRR, sumRecall float64
+	var totalPostingsRead, totalIndexSearches int
 	for _, q := range queries {
 		latencies = append(latencies, q.Latency)
+		diagnosticsTotals = append(diagnosticsTotals, q.DiagnosticsTotal)
+		searchTimings = append(searchTimings, q.DiagnosticsSearchTokens)
 		sumNDCG += q.NDCG
 		sumMRR += q.MRR
 		sumRecall += q.Recall
+		totalPostingsRead += q.PostingEntriesRead
+		totalIndexSearches += q.IndexSearches
+
+		strategy := q.ExecutionStrategy
+		if strategy == "" {
+			strategy = "unknown"
+		}
+		st := report.Strategies[strategy]
+		st.Count++
+		st.TotalDuration += q.DiagnosticsTotal
+		st.TotalSearchTokens += q.DiagnosticsSearchTokens
+		st.TotalPostingsRead += q.PostingEntriesRead
+		st.TotalIndexSearch += q.IndexSearches
+		report.Strategies[strategy] = st
 	}
 
 	n := float64(len(queries))
 	report.MeanNDCG = sumNDCG / n
 	report.MeanMRR = sumMRR / n
 	report.MeanRecall = sumRecall / n
+	report.MeanPostingEntriesRead = float64(totalPostingsRead) / n
+	report.MeanIndexSearches = float64(totalIndexSearches) / n
 	report.LatencyP50 = Percentile(latencies, 0.50)
 	report.LatencyP95 = Percentile(latencies, 0.95)
 	report.LatencyP99 = Percentile(latencies, 0.99)
+	report.DiagnosticsTotalP50 = Percentile(diagnosticsTotals, 0.50)
+	report.DiagnosticsTotalP95 = Percentile(diagnosticsTotals, 0.95)
+	report.DiagnosticsTotalP99 = Percentile(diagnosticsTotals, 0.99)
+	report.DiagnosticsSearchP50 = Percentile(searchTimings, 0.50)
+	report.DiagnosticsSearchP95 = Percentile(searchTimings, 0.95)
+	report.DiagnosticsSearchP99 = Percentile(searchTimings, 0.99)
 
 	sort.SliceStable(report.Queries, func(i, j int) bool {
 		return report.Queries[i].NDCG < report.Queries[j].NDCG
@@ -185,6 +245,32 @@ func WriteReport(w io.Writer, r Report, topWorst int) {
 	fmt.Fprintf(w, "  MRR:       %.4f\n", r.MeanMRR)
 	fmt.Fprintf(w, "  Recall@%d: %.4f\n", r.K, r.MeanRecall)
 	fmt.Fprintf(w, "  latency:   p50=%s p95=%s p99=%s\n", r.LatencyP50, r.LatencyP95, r.LatencyP99)
+	fmt.Fprintf(w, "  diag.total: p50=%s p95=%s p99=%s\n", r.DiagnosticsTotalP50, r.DiagnosticsTotalP95, r.DiagnosticsTotalP99)
+	fmt.Fprintf(w, "  diag.search_tokens: p50=%s p95=%s p99=%s\n", r.DiagnosticsSearchP50, r.DiagnosticsSearchP95, r.DiagnosticsSearchP99)
+	fmt.Fprintf(w, "  avg internal work: postings=%.1f index_lookups=%.1f\n", r.MeanPostingEntriesRead, r.MeanIndexSearches)
+
+	if len(r.Strategies) > 0 {
+		keys := make([]string, 0, len(r.Strategies))
+		for key := range r.Strategies {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		fmt.Fprintln(w, "  strategies:")
+		for _, key := range keys {
+			st := r.Strategies[key]
+			avgTotal := time.Duration(0)
+			avgSearch := time.Duration(0)
+			avgPostings := 0.0
+			avgLookups := 0.0
+			if st.Count > 0 {
+				avgTotal = st.TotalDuration / time.Duration(st.Count)
+				avgSearch = st.TotalSearchTokens / time.Duration(st.Count)
+				avgPostings = float64(st.TotalPostingsRead) / float64(st.Count)
+				avgLookups = float64(st.TotalIndexSearch) / float64(st.Count)
+			}
+			fmt.Fprintf(w, "    %s: count=%d avg_total=%s avg_search_tokens=%s avg_postings=%.1f avg_lookups=%.1f\n", key, st.Count, avgTotal, avgSearch, avgPostings, avgLookups)
+		}
+	}
 
 	if topWorst <= 0 || len(r.Queries) == 0 {
 		return
@@ -196,6 +282,6 @@ func WriteReport(w io.Writer, r Report, topWorst int) {
 	fmt.Fprintf(w, "\nWorst %d queries by nDCG@%d:\n", topWorst, r.K)
 	for i := 0; i < topWorst; i++ {
 		q := r.Queries[i]
-		fmt.Fprintf(w, "  ndcg=%.3f mrr=%.3f recall=%.3f lat=%s  %q\n", q.NDCG, q.MRR, q.Recall, q.Latency, q.Query)
+		fmt.Fprintf(w, "  ndcg=%.3f mrr=%.3f recall=%.3f lat=%s strategy=%s postings=%d lookups=%d  %q\n", q.NDCG, q.MRR, q.Recall, q.Latency, q.ExecutionStrategy, q.PostingEntriesRead, q.IndexSearches, q.Query)
 	}
 }

--- a/internal/bench/harness.go
+++ b/internal/bench/harness.go
@@ -49,17 +49,21 @@ type QueryReport struct {
 	MRR                     float64
 	Recall                  float64
 	Latency                 time.Duration
+	LogicalQueryType        string
 	ExecutionStrategy       string
 	StrategySkipReason      string
 	IndexSearches           int
 	PostingEntriesRead      int
 	DiagnosticsTotal        time.Duration
 	DiagnosticsSearchTokens time.Duration
+	WANDUsed                bool
+	WANDSkipReason          string
 }
 
 type StrategyReport struct {
 	Count             int
 	TotalDuration     time.Duration
+	P95Duration       time.Duration
 	TotalSearchTokens time.Duration
 	TotalPostingsRead int
 	TotalIndexSearch  int
@@ -78,6 +82,7 @@ type Report struct {
 	K                      int
 	Index                  IndexReport
 	Queries                []QueryReport
+	ZeroResults            int
 	LatencyP50             time.Duration
 	LatencyP95             time.Duration
 	LatencyP99             time.Duration
@@ -93,6 +98,10 @@ type Report struct {
 	MeanPostingEntriesRead float64
 	MeanIndexSearches      float64
 	Strategies             map[string]StrategyReport
+	WANDUsed               int
+	WANDSkipped            int
+	WANDSkipReasons        map[string]int
+	FallbackReasons        map[string]int
 }
 
 func IndexCorpus(ctx context.Context, svc *pkgfts.Service, corpus Corpus, content ContentSelector) (IndexReport, error) {
@@ -232,19 +241,32 @@ func runQuery(ctx context.Context, svc *pkgfts.Service, q Query, titleIdx map[st
 		Latency:  elapsed,
 	}
 	if diag := res.Diagnostics; diag != nil {
+		queryReport.LogicalQueryType = diag.LogicalQueryType
 		queryReport.ExecutionStrategy = diag.ExecutionStrategy
 		queryReport.StrategySkipReason = diag.StrategySkipReason
 		queryReport.IndexSearches = diag.IndexSearches
 		queryReport.PostingEntriesRead = diag.PostingEntriesRead
 		queryReport.DiagnosticsTotal = diag.Timings.Total
 		queryReport.DiagnosticsSearchTokens = diag.Timings.SearchTokens
+		if diag.Boolean != nil {
+			queryReport.WANDUsed = diag.Boolean.WAND.Used
+			queryReport.WANDSkipReason = diag.Boolean.WAND.SkipReason
+		}
 	}
 
 	return queryReport, nil
 }
 
 func Aggregate(k int, idx IndexReport, queries []QueryReport, diagnosticsEnabled bool) Report {
-	report := Report{DiagnosticsEnabled: diagnosticsEnabled, K: k, Index: idx, Queries: queries, Strategies: make(map[string]StrategyReport)}
+	report := Report{
+		DiagnosticsEnabled: diagnosticsEnabled,
+		K:                  k,
+		Index:              idx,
+		Queries:            queries,
+		Strategies:         make(map[string]StrategyReport),
+		WANDSkipReasons:    make(map[string]int),
+		FallbackReasons:    make(map[string]int),
+	}
 	if len(queries) == 0 {
 		return report
 	}
@@ -252,10 +274,14 @@ func Aggregate(k int, idx IndexReport, queries []QueryReport, diagnosticsEnabled
 	latencies := make([]time.Duration, 0, len(queries))
 	diagnosticsTotals := make([]time.Duration, 0, len(queries))
 	searchTimings := make([]time.Duration, 0, len(queries))
+	strategyDurations := make(map[string][]time.Duration)
 	var sumNDCG, sumMRR, sumRecall float64
 	var totalPostingsRead, totalIndexSearches int
 	for _, q := range queries {
 		latencies = append(latencies, q.Latency)
+		if q.Returned == 0 {
+			report.ZeroResults++
+		}
 		if diagnosticsEnabled {
 			diagnosticsTotals = append(diagnosticsTotals, q.DiagnosticsTotal)
 			searchTimings = append(searchTimings, q.DiagnosticsSearchTokens)
@@ -280,6 +306,18 @@ func Aggregate(k int, idx IndexReport, queries []QueryReport, diagnosticsEnabled
 			st.TotalPostingsRead += q.PostingEntriesRead
 			st.TotalIndexSearch += q.IndexSearches
 			report.Strategies[strategy] = st
+			strategyDurations[strategy] = append(strategyDurations[strategy], q.DiagnosticsTotal)
+
+			if q.WANDUsed {
+				report.WANDUsed++
+			}
+			if q.WANDSkipReason != "" {
+				report.WANDSkipped++
+				report.WANDSkipReasons[q.WANDSkipReason]++
+			}
+			if q.StrategySkipReason != "" {
+				report.FallbackReasons[q.StrategySkipReason]++
+			}
 		}
 	}
 
@@ -299,6 +337,10 @@ func Aggregate(k int, idx IndexReport, queries []QueryReport, diagnosticsEnabled
 		report.DiagnosticsSearchP50 = Percentile(searchTimings, 0.50)
 		report.DiagnosticsSearchP95 = Percentile(searchTimings, 0.95)
 		report.DiagnosticsSearchP99 = Percentile(searchTimings, 0.99)
+		for strategy, st := range report.Strategies {
+			st.P95Duration = Percentile(strategyDurations[strategy], 0.95)
+			report.Strategies[strategy] = st
+		}
 	}
 
 	sort.SliceStable(report.Queries, func(i, j int) bool {
@@ -307,12 +349,44 @@ func Aggregate(k int, idx IndexReport, queries []QueryReport, diagnosticsEnabled
 	return report
 }
 
+func sortCountKeys(m map[string]int) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if m[keys[i]] != m[keys[j]] {
+			return m[keys[i]] > m[keys[j]]
+		}
+		return keys[i] < keys[j]
+	})
+	return keys
+}
+
+func topQueriesByPostings(queries []QueryReport, limit int) []QueryReport {
+	if limit <= 0 || len(queries) == 0 {
+		return nil
+	}
+	if limit > len(queries) {
+		limit = len(queries)
+	}
+	out := append([]QueryReport(nil), queries...)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].PostingEntriesRead != out[j].PostingEntriesRead {
+			return out[i].PostingEntriesRead > out[j].PostingEntriesRead
+		}
+		return out[i].Latency > out[j].Latency
+	})
+	return out[:limit]
+}
+
 func WriteReport(w io.Writer, r Report, topWorst int) {
 	fmt.Fprintf(w, "Indexed:   %d docs in %s (heap %d MB)\n", r.Index.DocumentCount, r.Index.Duration, r.Index.HeapAllocMB)
 	fmt.Fprintf(w, "Queries:   %d   (k=%d)\n", len(r.Queries), r.K)
 	fmt.Fprintf(w, "  nDCG@%d:   %.4f\n", r.K, r.MeanNDCG)
 	fmt.Fprintf(w, "  MRR:       %.4f\n", r.MeanMRR)
 	fmt.Fprintf(w, "  Recall@%d: %.4f\n", r.K, r.MeanRecall)
+	fmt.Fprintf(w, "  zero_results: %d\n", r.ZeroResults)
 	fmt.Fprintf(w, "  latency:   p50=%s p95=%s p99=%s\n", r.LatencyP50, r.LatencyP95, r.LatencyP99)
 	if r.DiagnosticsEnabled {
 		fmt.Fprintf(w, "  diag.total: p50=%s p95=%s p99=%s\n", r.DiagnosticsTotalP50, r.DiagnosticsTotalP95, r.DiagnosticsTotalP99)
@@ -339,7 +413,24 @@ func WriteReport(w io.Writer, r Report, topWorst int) {
 				avgPostings = float64(st.TotalPostingsRead) / float64(st.Count)
 				avgLookups = float64(st.TotalIndexSearch) / float64(st.Count)
 			}
-			fmt.Fprintf(w, "    %s: count=%d avg_total=%s avg_search_tokens=%s avg_postings=%.1f avg_lookups=%.1f\n", key, st.Count, avgTotal, avgSearch, avgPostings, avgLookups)
+			fmt.Fprintf(w, "    %s: count=%d avg_total=%s p95_total=%s avg_search_tokens=%s avg_postings=%.1f avg_lookups=%.1f\n", key, st.Count, avgTotal, st.P95Duration, avgSearch, avgPostings, avgLookups)
+		}
+
+		if r.WANDUsed > 0 || len(r.WANDSkipReasons) > 0 {
+			fmt.Fprintf(w, "  wand: used=%d skipped=%d\n", r.WANDUsed, r.WANDSkipped)
+			if len(r.WANDSkipReasons) > 0 {
+				fmt.Fprintln(w, "  wand skipped reasons:")
+				for _, key := range sortCountKeys(r.WANDSkipReasons) {
+					fmt.Fprintf(w, "    %s: %d\n", key, r.WANDSkipReasons[key])
+				}
+			}
+		}
+
+		if len(r.FallbackReasons) > 0 {
+			fmt.Fprintln(w, "  fallback reasons:")
+			for _, key := range sortCountKeys(r.FallbackReasons) {
+				fmt.Fprintf(w, "    %s: %d\n", key, r.FallbackReasons[key])
+			}
 		}
 	}
 
@@ -358,5 +449,19 @@ func WriteReport(w io.Writer, r Report, topWorst int) {
 			continue
 		}
 		fmt.Fprintf(w, "  ndcg=%.3f mrr=%.3f recall=%.3f lat=%s  %q\n", q.NDCG, q.MRR, q.Recall, q.Latency, q.Query)
+	}
+
+	if !r.DiagnosticsEnabled {
+		return
+	}
+
+	byPostings := topQueriesByPostings(r.Queries, topWorst)
+	if len(byPostings) == 0 {
+		return
+	}
+
+	fmt.Fprintf(w, "\nWorst %d queries by postings_read:\n", len(byPostings))
+	for _, q := range byPostings {
+		fmt.Fprintf(w, "  postings=%d lookups=%d lat=%s strategy=%s ndcg=%.3f  %q\n", q.PostingEntriesRead, q.IndexSearches, q.Latency, q.ExecutionStrategy, q.NDCG, q.Query)
 	}
 }

--- a/internal/bench/harness.go
+++ b/internal/bench/harness.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/rand"
 	"runtime"
 	"sort"
 	"strings"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/dariasmyr/fts-engine/internal/domain/models"
 	pkgfts "github.com/dariasmyr/fts-engine/pkg/fts"
+	"github.com/dariasmyr/fts-engine/pkg/ftsstats"
 )
 
 type Corpus []models.Document
@@ -63,7 +65,16 @@ type StrategyReport struct {
 	TotalIndexSearch  int
 }
 
+type RunQueryOptions struct {
+	Diagnostics bool
+	Observer    *ftsstats.SearchStats
+	Repeat      int
+	Warmup      int
+	Shuffle     bool
+}
+
 type Report struct {
+	DiagnosticsEnabled     bool
 	K                      int
 	Index                  IndexReport
 	Queries                []QueryReport
@@ -139,52 +150,101 @@ func CountMissingTitles(gt *GroundTruth, titleIdx map[string]string) int {
 	return missing
 }
 
-func RunQueries(ctx context.Context, svc *pkgfts.Service, gt *GroundTruth, titleIdx map[string]string, k int) ([]QueryReport, error) {
-	reports := make([]QueryReport, 0, len(gt.Queries))
-	searchCtx := pkgfts.WithDiagnostics(ctx)
-	for _, q := range gt.Queries {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
+func RunQueries(ctx context.Context, svc *pkgfts.Service, gt *GroundTruth, titleIdx map[string]string, k int, opts RunQueryOptions) ([]QueryReport, error) {
+	if opts.Repeat <= 0 {
+		opts.Repeat = 1
+	}
+	if opts.Warmup < 0 {
+		opts.Warmup = 0
+	}
+	rng := rand.New(rand.NewSource(1))
 
-		relevant := NewRelevanceSet(ResolveRelevant(q, titleIdx))
-		start := time.Now()
-		res, err := svc.SearchDocuments(searchCtx, q.Query, k)
-		elapsed := time.Since(start)
-		if err != nil {
-			return nil, fmt.Errorf("search %q: %w", q.Query, err)
+	reports := make([]QueryReport, 0, len(gt.Queries)*opts.Repeat)
+	for remaining := opts.Warmup; remaining > 0 && len(gt.Queries) > 0; {
+		batch := orderedQueries(gt.Queries, opts.Shuffle, rng)
+		if remaining < len(batch) {
+			batch = batch[:remaining]
 		}
+		for _, q := range batch {
+			if _, err := runQuery(ctx, svc, q, titleIdx, k, opts.Diagnostics, nil); err != nil {
+				return nil, fmt.Errorf("warmup search %q: %w", q.Query, err)
+			}
+		}
+		remaining -= len(batch)
+	}
 
-		ranked := make([]string, 0, len(res.Results))
-		for _, item := range res.Results {
-			ranked = append(ranked, string(item.ID))
+	for run := 0; run < opts.Repeat; run++ {
+		for _, q := range orderedQueries(gt.Queries, opts.Shuffle, rng) {
+			queryReport, err := runQuery(ctx, svc, q, titleIdx, k, opts.Diagnostics, opts.Observer)
+			if err != nil {
+				return nil, fmt.Errorf("search %q: %w", q.Query, err)
+			}
+			reports = append(reports, queryReport)
 		}
-
-		queryReport := QueryReport{
-			Query:    q.Query,
-			Returned: len(ranked),
-			Relevant: relevant.Size(),
-			NDCG:     NDCG(ranked, relevant, k),
-			MRR:      MRR(ranked, relevant),
-			Recall:   Recall(ranked, relevant, k),
-			Latency:  elapsed,
-		}
-		if diag := res.Diagnostics; diag != nil {
-			queryReport.ExecutionStrategy = diag.ExecutionStrategy
-			queryReport.StrategySkipReason = diag.StrategySkipReason
-			queryReport.IndexSearches = diag.IndexSearches
-			queryReport.PostingEntriesRead = diag.PostingEntriesRead
-			queryReport.DiagnosticsTotal = diag.Timings.Total
-			queryReport.DiagnosticsSearchTokens = diag.Timings.SearchTokens
-		}
-
-		reports = append(reports, queryReport)
 	}
 	return reports, nil
 }
 
-func Aggregate(k int, idx IndexReport, queries []QueryReport) Report {
-	report := Report{K: k, Index: idx, Queries: queries, Strategies: make(map[string]StrategyReport)}
+func orderedQueries(in []Query, shuffle bool, rng *rand.Rand) []Query {
+	out := append([]Query(nil), in...)
+	if !shuffle || len(out) < 2 {
+		return out
+	}
+	rng.Shuffle(len(out), func(i, j int) {
+		out[i], out[j] = out[j], out[i]
+	})
+	return out
+}
+
+func runQuery(ctx context.Context, svc *pkgfts.Service, q Query, titleIdx map[string]string, k int, diagnostics bool, observer *ftsstats.SearchStats) (QueryReport, error) {
+	if err := ctx.Err(); err != nil {
+		return QueryReport{}, err
+	}
+
+	searchCtx := ctx
+	if diagnostics {
+		searchCtx = pkgfts.WithDiagnostics(searchCtx)
+	}
+
+	relevant := NewRelevanceSet(ResolveRelevant(q, titleIdx))
+	start := time.Now()
+	res, err := svc.SearchDocuments(searchCtx, q.Query, k)
+	elapsed := time.Since(start)
+	if observer != nil {
+		observer.ObserveResult(q.Query, res, err)
+	}
+	if err != nil {
+		return QueryReport{}, err
+	}
+
+	ranked := make([]string, 0, len(res.Results))
+	for _, item := range res.Results {
+		ranked = append(ranked, string(item.ID))
+	}
+
+	queryReport := QueryReport{
+		Query:    q.Query,
+		Returned: len(ranked),
+		Relevant: relevant.Size(),
+		NDCG:     NDCG(ranked, relevant, k),
+		MRR:      MRR(ranked, relevant),
+		Recall:   Recall(ranked, relevant, k),
+		Latency:  elapsed,
+	}
+	if diag := res.Diagnostics; diag != nil {
+		queryReport.ExecutionStrategy = diag.ExecutionStrategy
+		queryReport.StrategySkipReason = diag.StrategySkipReason
+		queryReport.IndexSearches = diag.IndexSearches
+		queryReport.PostingEntriesRead = diag.PostingEntriesRead
+		queryReport.DiagnosticsTotal = diag.Timings.Total
+		queryReport.DiagnosticsSearchTokens = diag.Timings.SearchTokens
+	}
+
+	return queryReport, nil
+}
+
+func Aggregate(k int, idx IndexReport, queries []QueryReport, diagnosticsEnabled bool) Report {
+	report := Report{DiagnosticsEnabled: diagnosticsEnabled, K: k, Index: idx, Queries: queries, Strategies: make(map[string]StrategyReport)}
 	if len(queries) == 0 {
 		return report
 	}
@@ -196,42 +256,50 @@ func Aggregate(k int, idx IndexReport, queries []QueryReport) Report {
 	var totalPostingsRead, totalIndexSearches int
 	for _, q := range queries {
 		latencies = append(latencies, q.Latency)
-		diagnosticsTotals = append(diagnosticsTotals, q.DiagnosticsTotal)
-		searchTimings = append(searchTimings, q.DiagnosticsSearchTokens)
+		if diagnosticsEnabled {
+			diagnosticsTotals = append(diagnosticsTotals, q.DiagnosticsTotal)
+			searchTimings = append(searchTimings, q.DiagnosticsSearchTokens)
+		}
 		sumNDCG += q.NDCG
 		sumMRR += q.MRR
 		sumRecall += q.Recall
-		totalPostingsRead += q.PostingEntriesRead
-		totalIndexSearches += q.IndexSearches
-
-		strategy := q.ExecutionStrategy
-		if strategy == "" {
-			strategy = "unknown"
+		if diagnosticsEnabled {
+			totalPostingsRead += q.PostingEntriesRead
+			totalIndexSearches += q.IndexSearches
 		}
-		st := report.Strategies[strategy]
-		st.Count++
-		st.TotalDuration += q.DiagnosticsTotal
-		st.TotalSearchTokens += q.DiagnosticsSearchTokens
-		st.TotalPostingsRead += q.PostingEntriesRead
-		st.TotalIndexSearch += q.IndexSearches
-		report.Strategies[strategy] = st
+
+		if diagnosticsEnabled {
+			strategy := q.ExecutionStrategy
+			if strategy == "" {
+				strategy = "unknown"
+			}
+			st := report.Strategies[strategy]
+			st.Count++
+			st.TotalDuration += q.DiagnosticsTotal
+			st.TotalSearchTokens += q.DiagnosticsSearchTokens
+			st.TotalPostingsRead += q.PostingEntriesRead
+			st.TotalIndexSearch += q.IndexSearches
+			report.Strategies[strategy] = st
+		}
 	}
 
 	n := float64(len(queries))
 	report.MeanNDCG = sumNDCG / n
 	report.MeanMRR = sumMRR / n
 	report.MeanRecall = sumRecall / n
-	report.MeanPostingEntriesRead = float64(totalPostingsRead) / n
-	report.MeanIndexSearches = float64(totalIndexSearches) / n
 	report.LatencyP50 = Percentile(latencies, 0.50)
 	report.LatencyP95 = Percentile(latencies, 0.95)
 	report.LatencyP99 = Percentile(latencies, 0.99)
-	report.DiagnosticsTotalP50 = Percentile(diagnosticsTotals, 0.50)
-	report.DiagnosticsTotalP95 = Percentile(diagnosticsTotals, 0.95)
-	report.DiagnosticsTotalP99 = Percentile(diagnosticsTotals, 0.99)
-	report.DiagnosticsSearchP50 = Percentile(searchTimings, 0.50)
-	report.DiagnosticsSearchP95 = Percentile(searchTimings, 0.95)
-	report.DiagnosticsSearchP99 = Percentile(searchTimings, 0.99)
+	if diagnosticsEnabled {
+		report.MeanPostingEntriesRead = float64(totalPostingsRead) / n
+		report.MeanIndexSearches = float64(totalIndexSearches) / n
+		report.DiagnosticsTotalP50 = Percentile(diagnosticsTotals, 0.50)
+		report.DiagnosticsTotalP95 = Percentile(diagnosticsTotals, 0.95)
+		report.DiagnosticsTotalP99 = Percentile(diagnosticsTotals, 0.99)
+		report.DiagnosticsSearchP50 = Percentile(searchTimings, 0.50)
+		report.DiagnosticsSearchP95 = Percentile(searchTimings, 0.95)
+		report.DiagnosticsSearchP99 = Percentile(searchTimings, 0.99)
+	}
 
 	sort.SliceStable(report.Queries, func(i, j int) bool {
 		return report.Queries[i].NDCG < report.Queries[j].NDCG
@@ -246,11 +314,13 @@ func WriteReport(w io.Writer, r Report, topWorst int) {
 	fmt.Fprintf(w, "  MRR:       %.4f\n", r.MeanMRR)
 	fmt.Fprintf(w, "  Recall@%d: %.4f\n", r.K, r.MeanRecall)
 	fmt.Fprintf(w, "  latency:   p50=%s p95=%s p99=%s\n", r.LatencyP50, r.LatencyP95, r.LatencyP99)
-	fmt.Fprintf(w, "  diag.total: p50=%s p95=%s p99=%s\n", r.DiagnosticsTotalP50, r.DiagnosticsTotalP95, r.DiagnosticsTotalP99)
-	fmt.Fprintf(w, "  diag.search_tokens: p50=%s p95=%s p99=%s\n", r.DiagnosticsSearchP50, r.DiagnosticsSearchP95, r.DiagnosticsSearchP99)
-	fmt.Fprintf(w, "  avg internal work: postings=%.1f index_lookups=%.1f\n", r.MeanPostingEntriesRead, r.MeanIndexSearches)
+	if r.DiagnosticsEnabled {
+		fmt.Fprintf(w, "  diag.total: p50=%s p95=%s p99=%s\n", r.DiagnosticsTotalP50, r.DiagnosticsTotalP95, r.DiagnosticsTotalP99)
+		fmt.Fprintf(w, "  diag.search_tokens: p50=%s p95=%s p99=%s\n", r.DiagnosticsSearchP50, r.DiagnosticsSearchP95, r.DiagnosticsSearchP99)
+		fmt.Fprintf(w, "  avg internal work: postings=%.1f index_lookups=%.1f\n", r.MeanPostingEntriesRead, r.MeanIndexSearches)
+	}
 
-	if len(r.Strategies) > 0 {
+	if r.DiagnosticsEnabled && len(r.Strategies) > 0 {
 		keys := make([]string, 0, len(r.Strategies))
 		for key := range r.Strategies {
 			keys = append(keys, key)
@@ -283,6 +353,10 @@ func WriteReport(w io.Writer, r Report, topWorst int) {
 	fmt.Fprintf(w, "\nWorst %d queries by nDCG@%d:\n", topWorst, r.K)
 	for i := 0; i < topWorst; i++ {
 		q := r.Queries[i]
-		fmt.Fprintf(w, "  ndcg=%.3f mrr=%.3f recall=%.3f lat=%s strategy=%s postings=%d lookups=%d  %q\n", q.NDCG, q.MRR, q.Recall, q.Latency, q.ExecutionStrategy, q.PostingEntriesRead, q.IndexSearches, q.Query)
+		if r.DiagnosticsEnabled {
+			fmt.Fprintf(w, "  ndcg=%.3f mrr=%.3f recall=%.3f lat=%s strategy=%s postings=%d lookups=%d  %q\n", q.NDCG, q.MRR, q.Recall, q.Latency, q.ExecutionStrategy, q.PostingEntriesRead, q.IndexSearches, q.Query)
+			continue
+		}
+		fmt.Fprintf(w, "  ndcg=%.3f mrr=%.3f recall=%.3f lat=%s  %q\n", q.NDCG, q.MRR, q.Recall, q.Latency, q.Query)
 	}
 }

--- a/internal/bench/harness.go
+++ b/internal/bench/harness.go
@@ -141,6 +141,7 @@ func CountMissingTitles(gt *GroundTruth, titleIdx map[string]string) int {
 
 func RunQueries(ctx context.Context, svc *pkgfts.Service, gt *GroundTruth, titleIdx map[string]string, k int) ([]QueryReport, error) {
 	reports := make([]QueryReport, 0, len(gt.Queries))
+	searchCtx := pkgfts.WithDiagnostics(ctx)
 	for _, q := range gt.Queries {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -148,7 +149,7 @@ func RunQueries(ctx context.Context, svc *pkgfts.Service, gt *GroundTruth, title
 
 		relevant := NewRelevanceSet(ResolveRelevant(q, titleIdx))
 		start := time.Now()
-		res, err := svc.SearchDocuments(ctx, q.Query, k)
+		res, err := svc.SearchDocuments(searchCtx, q.Query, k)
 		elapsed := time.Since(start)
 		if err != nil {
 			return nil, fmt.Errorf("search %q: %w", q.Query, err)

--- a/internal/bench/harness_test.go
+++ b/internal/bench/harness_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dariasmyr/fts-engine/internal/domain/models"
 	"github.com/dariasmyr/fts-engine/pkg/fts"
@@ -90,6 +91,14 @@ func TestIndexAndRunQueriesEndToEnd(t *testing.T) {
 	if len(queryReports) != 2 {
 		t.Fatalf("len(queryReports) = %d, want 2", len(queryReports))
 	}
+	for _, qr := range queryReports {
+		if qr.ExecutionStrategy == "" {
+			t.Fatalf("query %q missing ExecutionStrategy", qr.Query)
+		}
+		if qr.DiagnosticsTotal <= 0 {
+			t.Fatalf("query %q missing DiagnosticsTotal, got %v", qr.Query, qr.DiagnosticsTotal)
+		}
+	}
 
 	report := Aggregate(10, idxReport, queryReports)
 	if report.MeanNDCG <= 0 {
@@ -97,5 +106,64 @@ func TestIndexAndRunQueriesEndToEnd(t *testing.T) {
 	}
 	if report.MeanMRR <= 0 {
 		t.Fatalf("MeanMRR = %v, want > 0", report.MeanMRR)
+	}
+	if report.DiagnosticsTotalP50 <= 0 {
+		t.Fatalf("DiagnosticsTotalP50 = %v, want > 0", report.DiagnosticsTotalP50)
+	}
+	strategyCount := 0
+	for _, st := range report.Strategies {
+		strategyCount += st.Count
+	}
+	if strategyCount != len(queryReports) {
+		t.Fatalf("strategy counts sum = %d, want %d (strategies=%+v)", strategyCount, len(queryReports), report.Strategies)
+	}
+}
+
+func TestAggregateIncludesDiagnosticsAndStrategies(t *testing.T) {
+	queries := []QueryReport{
+		{
+			Query:                   "alpha",
+			NDCG:                    1,
+			MRR:                     1,
+			Recall:                  1,
+			Latency:                 10 * time.Millisecond,
+			ExecutionStrategy:       "term",
+			IndexSearches:           2,
+			PostingEntriesRead:      5,
+			DiagnosticsTotal:        8 * time.Millisecond,
+			DiagnosticsSearchTokens: 6 * time.Millisecond,
+		},
+		{
+			Query:                   "alpha beta",
+			NDCG:                    0.5,
+			MRR:                     0.5,
+			Recall:                  0.5,
+			Latency:                 20 * time.Millisecond,
+			ExecutionStrategy:       "bool_or_wand",
+			IndexSearches:           4,
+			PostingEntriesRead:      15,
+			DiagnosticsTotal:        16 * time.Millisecond,
+			DiagnosticsSearchTokens: 12 * time.Millisecond,
+		},
+	}
+
+	report := Aggregate(10, IndexReport{}, queries)
+	if report.DiagnosticsTotalP50 != 12*time.Millisecond {
+		t.Fatalf("DiagnosticsTotalP50 = %v, want 12ms", report.DiagnosticsTotalP50)
+	}
+	if report.DiagnosticsSearchP50 != 9*time.Millisecond {
+		t.Fatalf("DiagnosticsSearchP50 = %v, want 9ms", report.DiagnosticsSearchP50)
+	}
+	if report.MeanPostingEntriesRead != 10 {
+		t.Fatalf("MeanPostingEntriesRead = %v, want 10", report.MeanPostingEntriesRead)
+	}
+	if report.MeanIndexSearches != 3 {
+		t.Fatalf("MeanIndexSearches = %v, want 3", report.MeanIndexSearches)
+	}
+	if report.Strategies["term"].Count != 1 {
+		t.Fatalf("term strategy count = %d, want 1", report.Strategies["term"].Count)
+	}
+	if report.Strategies["bool_or_wand"].TotalPostingsRead != 15 {
+		t.Fatalf("bool_or_wand postings = %d, want 15", report.Strategies["bool_or_wand"].TotalPostingsRead)
 	}
 }

--- a/internal/bench/harness_test.go
+++ b/internal/bench/harness_test.go
@@ -2,12 +2,14 @@ package bench
 
 import (
 	"context"
+	"math/rand"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/dariasmyr/fts-engine/internal/domain/models"
 	"github.com/dariasmyr/fts-engine/pkg/fts"
+	"github.com/dariasmyr/fts-engine/pkg/ftsstats"
 	"github.com/dariasmyr/fts-engine/pkg/index/radix"
 	"github.com/dariasmyr/fts-engine/pkg/keygen"
 )
@@ -84,7 +86,7 @@ func TestIndexAndRunQueriesEndToEnd(t *testing.T) {
 	}}
 
 	titleIdx := corpus.TitleIndex()
-	queryReports, err := RunQueries(ctx, svc, gt, titleIdx, 10)
+	queryReports, err := RunQueries(ctx, svc, gt, titleIdx, 10, RunQueryOptions{Diagnostics: true})
 	if err != nil {
 		t.Fatalf("RunQueries() error = %v", err)
 	}
@@ -100,7 +102,7 @@ func TestIndexAndRunQueriesEndToEnd(t *testing.T) {
 		}
 	}
 
-	report := Aggregate(10, idxReport, queryReports)
+	report := Aggregate(10, idxReport, queryReports, true)
 	if report.MeanNDCG <= 0 {
 		t.Fatalf("MeanNDCG = %v, want > 0", report.MeanNDCG)
 	}
@@ -116,6 +118,142 @@ func TestIndexAndRunQueriesEndToEnd(t *testing.T) {
 	}
 	if strategyCount != len(queryReports) {
 		t.Fatalf("strategy counts sum = %d, want %d (strategies=%+v)", strategyCount, len(queryReports), report.Strategies)
+	}
+}
+
+func TestRunQueriesWithoutDiagnosticsLeavesInstrumentationFieldsEmpty(t *testing.T) {
+	ctx := context.Background()
+	corpus := Corpus{mkDoc("1", "Rosa Barge", "Rosa is a French hotel barge on the Canal du Midi")}
+
+	svc := fts.New(radix.New(), keygen.Word)
+	if _, err := IndexCorpus(ctx, svc, corpus, SelectAbstract); err != nil {
+		t.Fatalf("IndexCorpus() error = %v", err)
+	}
+
+	gt := &GroundTruth{Queries: []Query{{Query: "french hotel barge", RelevantTitles: []string{"Rosa Barge"}}}}
+	queryReports, err := RunQueries(ctx, svc, gt, corpus.TitleIndex(), 10, RunQueryOptions{})
+	if err != nil {
+		t.Fatalf("RunQueries() error = %v", err)
+	}
+	if len(queryReports) != 1 {
+		t.Fatalf("len(queryReports) = %d, want 1", len(queryReports))
+	}
+	qr := queryReports[0]
+	if qr.ExecutionStrategy != "" || qr.DiagnosticsTotal != 0 || qr.DiagnosticsSearchTokens != 0 || qr.IndexSearches != 0 || qr.PostingEntriesRead != 0 {
+		t.Fatalf("expected empty diagnostics fields, got %+v", qr)
+	}
+
+	report := Aggregate(10, IndexReport{}, queryReports, false)
+	if report.DiagnosticsEnabled {
+		t.Fatal("expected DiagnosticsEnabled to be false")
+	}
+	if len(report.Strategies) != 0 {
+		t.Fatalf("expected no strategy breakdown without diagnostics, got %+v", report.Strategies)
+	}
+}
+
+func TestRunQueriesObserverTracksQueriesWithoutDiagnostics(t *testing.T) {
+	ctx := context.Background()
+	corpus := Corpus{mkDoc("1", "Rosa Barge", "Rosa is a French hotel barge on the Canal du Midi")}
+
+	svc := fts.New(radix.New(), keygen.Word)
+	if _, err := IndexCorpus(ctx, svc, corpus, SelectAbstract); err != nil {
+		t.Fatalf("IndexCorpus() error = %v", err)
+	}
+
+	gt := &GroundTruth{Queries: []Query{{Query: "french hotel barge", RelevantTitles: []string{"Rosa Barge"}}}}
+	stats := ftsstats.NewSearchStats(8)
+	if _, err := RunQueries(ctx, svc, gt, corpus.TitleIndex(), 10, RunQueryOptions{Observer: stats}); err != nil {
+		t.Fatalf("RunQueries() error = %v", err)
+	}
+
+	snap := stats.Snapshot()
+	if snap.TotalSearches != 1 {
+		t.Fatalf("TotalSearches = %d, want 1", snap.TotalSearches)
+	}
+	if len(snap.ByStrategy) != 0 {
+		t.Fatalf("expected no strategy stats without diagnostics, got %+v", snap.ByStrategy)
+	}
+	if len(snap.Recent) != 1 {
+		t.Fatalf("Recent size = %d, want 1", len(snap.Recent))
+	}
+}
+
+func TestRunQueriesRepeatMultipliesMeasuredRuns(t *testing.T) {
+	ctx := context.Background()
+	corpus := Corpus{mkDoc("1", "Rosa Barge", "Rosa is a French hotel barge on the Canal du Midi")}
+
+	svc := fts.New(radix.New(), keygen.Word)
+	if _, err := IndexCorpus(ctx, svc, corpus, SelectAbstract); err != nil {
+		t.Fatalf("IndexCorpus() error = %v", err)
+	}
+
+	gt := &GroundTruth{Queries: []Query{{Query: "french hotel barge", RelevantTitles: []string{"Rosa Barge"}}}}
+	stats := ftsstats.NewSearchStats(8)
+	queryReports, err := RunQueries(ctx, svc, gt, corpus.TitleIndex(), 10, RunQueryOptions{Observer: stats, Repeat: 3})
+	if err != nil {
+		t.Fatalf("RunQueries() error = %v", err)
+	}
+	if len(queryReports) != 3 {
+		t.Fatalf("len(queryReports) = %d, want 3", len(queryReports))
+	}
+	snap := stats.Snapshot()
+	if snap.TotalSearches != 3 {
+		t.Fatalf("TotalSearches = %d, want 3", snap.TotalSearches)
+	}
+}
+
+func TestRunQueriesWarmupDoesNotAffectMeasuredReportsOrObserver(t *testing.T) {
+	ctx := context.Background()
+	corpus := Corpus{mkDoc("1", "Rosa Barge", "Rosa is a French hotel barge on the Canal du Midi")}
+
+	svc := fts.New(radix.New(), keygen.Word)
+	if _, err := IndexCorpus(ctx, svc, corpus, SelectAbstract); err != nil {
+		t.Fatalf("IndexCorpus() error = %v", err)
+	}
+
+	gt := &GroundTruth{Queries: []Query{{Query: "french hotel barge", RelevantTitles: []string{"Rosa Barge"}}}}
+	stats := ftsstats.NewSearchStats(8)
+	queryReports, err := RunQueries(ctx, svc, gt, corpus.TitleIndex(), 10, RunQueryOptions{Observer: stats, Repeat: 2, Warmup: 5})
+	if err != nil {
+		t.Fatalf("RunQueries() error = %v", err)
+	}
+	if len(queryReports) != 2 {
+		t.Fatalf("len(queryReports) = %d, want 2", len(queryReports))
+	}
+	snap := stats.Snapshot()
+	if snap.TotalSearches != 2 {
+		t.Fatalf("TotalSearches = %d, want 2", snap.TotalSearches)
+	}
+	if len(snap.Recent) != 2 {
+		t.Fatalf("Recent size = %d, want 2", len(snap.Recent))
+	}
+}
+
+func TestOrderedQueriesShufflePreservesMembersAndCanChangeOrder(t *testing.T) {
+	in := []Query{{Query: "one"}, {Query: "two"}, {Query: "three"}, {Query: "four"}, {Query: "five"}}
+	out := orderedQueries(in, true, rand.New(rand.NewSource(1)))
+	if len(out) != len(in) {
+		t.Fatalf("len(out) = %d, want %d", len(out), len(in))
+	}
+	seen := make(map[string]int, len(out))
+	for _, q := range out {
+		seen[q.Query]++
+	}
+	for _, q := range in {
+		if seen[q.Query] != 1 {
+			t.Fatalf("query %q count = %d, want 1", q.Query, seen[q.Query])
+		}
+	}
+	sameOrder := true
+	for i := range in {
+		if in[i].Query != out[i].Query {
+			sameOrder = false
+			break
+		}
+	}
+	if sameOrder {
+		t.Fatal("expected shuffled order to differ from input order")
 	}
 }
 
@@ -147,7 +285,7 @@ func TestAggregateIncludesDiagnosticsAndStrategies(t *testing.T) {
 		},
 	}
 
-	report := Aggregate(10, IndexReport{}, queries)
+	report := Aggregate(10, IndexReport{}, queries, true)
 	if report.DiagnosticsTotalP50 != 12*time.Millisecond {
 		t.Fatalf("DiagnosticsTotalP50 = %v, want 12ms", report.DiagnosticsTotalP50)
 	}

--- a/internal/bench/harness_test.go
+++ b/internal/bench/harness_test.go
@@ -1,6 +1,7 @@
 package bench
 
 import (
+	"bytes"
 	"context"
 	"math/rand"
 	"strings"
@@ -261,6 +262,7 @@ func TestAggregateIncludesDiagnosticsAndStrategies(t *testing.T) {
 	queries := []QueryReport{
 		{
 			Query:                   "alpha",
+			Returned:                1,
 			NDCG:                    1,
 			MRR:                     1,
 			Recall:                  1,
@@ -273,6 +275,7 @@ func TestAggregateIncludesDiagnosticsAndStrategies(t *testing.T) {
 		},
 		{
 			Query:                   "alpha beta",
+			Returned:                1,
 			NDCG:                    0.5,
 			MRR:                     0.5,
 			Recall:                  0.5,
@@ -303,5 +306,134 @@ func TestAggregateIncludesDiagnosticsAndStrategies(t *testing.T) {
 	}
 	if report.Strategies["bool_or_wand"].TotalPostingsRead != 15 {
 		t.Fatalf("bool_or_wand postings = %d, want 15", report.Strategies["bool_or_wand"].TotalPostingsRead)
+	}
+}
+
+func TestAggregateTracksZeroResultsWandAndFallbackReasons(t *testing.T) {
+	queries := []QueryReport{
+		{
+			Query:                   "wand used",
+			Returned:                2,
+			NDCG:                    1,
+			MRR:                     1,
+			Recall:                  1,
+			Latency:                 5 * time.Millisecond,
+			ExecutionStrategy:       "bool_or_wand",
+			IndexSearches:           3,
+			PostingEntriesRead:      11,
+			DiagnosticsTotal:        4 * time.Millisecond,
+			DiagnosticsSearchTokens: 3 * time.Millisecond,
+			WANDUsed:                true,
+		},
+		{
+			Query:                   "wand skipped",
+			Returned:                0,
+			NDCG:                    0,
+			MRR:                     0,
+			Recall:                  0,
+			Latency:                 7 * time.Millisecond,
+			ExecutionStrategy:       "bool_or_fast",
+			StrategySkipReason:      "wand_disabled_no_scorer",
+			IndexSearches:           4,
+			PostingEntriesRead:      17,
+			DiagnosticsTotal:        6 * time.Millisecond,
+			DiagnosticsSearchTokens: 5 * time.Millisecond,
+			WANDSkipReason:          "wand_disabled_no_scorer",
+		},
+	}
+
+	report := Aggregate(10, IndexReport{}, queries, true)
+	if report.ZeroResults != 1 {
+		t.Fatalf("ZeroResults = %d, want 1", report.ZeroResults)
+	}
+	if report.WANDUsed != 1 {
+		t.Fatalf("WANDUsed = %d, want 1", report.WANDUsed)
+	}
+	if report.WANDSkipped != 1 {
+		t.Fatalf("WANDSkipped = %d, want 1", report.WANDSkipped)
+	}
+	if report.WANDSkipReasons["wand_disabled_no_scorer"] != 1 {
+		t.Fatalf("WANDSkipReasons = %+v, want wand_disabled_no_scorer=1", report.WANDSkipReasons)
+	}
+	if report.FallbackReasons["wand_disabled_no_scorer"] != 1 {
+		t.Fatalf("FallbackReasons = %+v, want wand_disabled_no_scorer=1", report.FallbackReasons)
+	}
+}
+
+func TestWriteReportIncludesBenchDiagnosticsSections(t *testing.T) {
+	report := Report{
+		DiagnosticsEnabled: true,
+		K:                  10,
+		Index:              IndexReport{DocumentCount: 2, Duration: time.Second, HeapAllocMB: 123},
+		Queries: []QueryReport{
+			{
+				Query:                   "lighter",
+				Returned:                1,
+				NDCG:                    0.5,
+				MRR:                     0.5,
+				Recall:                  0.5,
+				Latency:                 2 * time.Millisecond,
+				ExecutionStrategy:       "bool_or_fast",
+				StrategySkipReason:      "wand_disabled_no_scorer",
+				IndexSearches:           2,
+				PostingEntriesRead:      9,
+				DiagnosticsTotal:        2 * time.Millisecond,
+				DiagnosticsSearchTokens: 1500 * time.Microsecond,
+				WANDSkipReason:          "wand_disabled_no_scorer",
+			},
+			{
+				Query:                   "heavier",
+				Returned:                0,
+				NDCG:                    1,
+				MRR:                     1,
+				Recall:                  1,
+				Latency:                 4 * time.Millisecond,
+				ExecutionStrategy:       "bool_or_wand",
+				IndexSearches:           3,
+				PostingEntriesRead:      25,
+				DiagnosticsTotal:        4 * time.Millisecond,
+				DiagnosticsSearchTokens: 3 * time.Millisecond,
+				WANDUsed:                true,
+			},
+		},
+		ZeroResults:            1,
+		LatencyP50:             3 * time.Millisecond,
+		LatencyP95:             3900 * time.Microsecond,
+		LatencyP99:             3980 * time.Microsecond,
+		DiagnosticsTotalP50:    3 * time.Millisecond,
+		DiagnosticsTotalP95:    3900 * time.Microsecond,
+		DiagnosticsTotalP99:    3980 * time.Microsecond,
+		DiagnosticsSearchP50:   2250 * time.Microsecond,
+		DiagnosticsSearchP95:   2925 * time.Microsecond,
+		DiagnosticsSearchP99:   2985 * time.Microsecond,
+		MeanNDCG:               0.75,
+		MeanMRR:                0.75,
+		MeanRecall:             0.75,
+		MeanPostingEntriesRead: 17,
+		MeanIndexSearches:      2.5,
+		Strategies: map[string]StrategyReport{
+			"bool_or_fast": {Count: 1, TotalDuration: 2 * time.Millisecond, P95Duration: 2 * time.Millisecond, TotalSearchTokens: 1500 * time.Microsecond, TotalPostingsRead: 9, TotalIndexSearch: 2},
+			"bool_or_wand": {Count: 1, TotalDuration: 4 * time.Millisecond, P95Duration: 4 * time.Millisecond, TotalSearchTokens: 3 * time.Millisecond, TotalPostingsRead: 25, TotalIndexSearch: 3},
+		},
+		WANDUsed:        1,
+		WANDSkipped:     1,
+		WANDSkipReasons: map[string]int{"wand_disabled_no_scorer": 1},
+		FallbackReasons: map[string]int{"wand_disabled_no_scorer": 1},
+	}
+
+	var buf bytes.Buffer
+	WriteReport(&buf, report, 1)
+	out := buf.String()
+	for _, needle := range []string{
+		"zero_results: 1",
+		"wand: used=1 skipped=1",
+		"wand skipped reasons:",
+		"fallback reasons:",
+		"Worst 1 queries by postings_read:",
+		"postings=25",
+	} {
+		if !strings.Contains(out, needle) {
+			t.Fatalf("expected output to contain %q, got:\n%s", needle, out)
+		}
 	}
 }

--- a/internal/bench/testdata/queries.abstract1.abstract.50.json
+++ b/internal/bench/testdata/queries.abstract1.abstract.50.json
@@ -1,0 +1,304 @@
+{
+  "queries": [
+    {
+      "query": "\"high precision atomic coordinate time standard based\"",
+      "relevant_titles": [
+        "Wikipedia: International Atomic Time"
+      ]
+    },
+    {
+      "query": "\"past including past human species social anthropology\"",
+      "relevant_titles": [
+        "Wikipedia: Anthropology"
+      ]
+    },
+    {
+      "query": "\"mainland southeast asia also scattered throughout parts\"",
+      "relevant_titles": [
+        "Wikipedia: Austroasiatic languages"
+      ]
+    },
+    {
+      "query": "\"traveling exploring skydiving mountain climbing scuba diving\"",
+      "relevant_titles": [
+        "Wikipedia: Adventure"
+      ]
+    },
+    {
+      "query": "\"plant taxa bearing flower like reproductive structures\"",
+      "relevant_titles": [
+        "Wikipedia: Anthophyta"
+      ]
+    },
+    {
+      "query": "\"european union armenian foreign policy between russia\"",
+      "relevant_titles": [
+        "Wikipedia: Foreign relations of Armenia"
+      ]
+    },
+    {
+      "query": "\"klein four group klein four group shown\"",
+      "relevant_titles": [
+        "Wikipedia: Automorphism"
+      ]
+    },
+    {
+      "query": "\"bellows driven free reed aerophone type colloquially\"",
+      "relevant_titles": [
+        "Wikipedia: Accordion"
+      ]
+    },
+    {
+      "query": "\"basic human needs including food safe drinking\"",
+      "relevant_titles": [
+        "Wikipedia: Extreme poverty"
+      ]
+    },
+    {
+      "query": "\"minimum vibrational motion retaining only quantum mechanical\"",
+      "relevant_titles": [
+        "Wikipedia: Absolute zero"
+      ]
+    },
+    {
+      "query": "\"counter ballistic missiles missile defense ballistic missiles\"",
+      "relevant_titles": [
+        "Wikipedia: Anti-ballistic missile"
+      ]
+    },
+    {
+      "query": "\"create turbulent airflow therefore approximants fall between\"",
+      "relevant_titles": [
+        "Wikipedia: Approximant"
+      ]
+    },
+    {
+      "query": "\"american english originally meant life vital force\"",
+      "relevant_titles": [
+        "Wikipedia: Aeon"
+      ]
+    },
+    {
+      "query": "\"plant trees today many countries observe such\"",
+      "relevant_titles": [
+        "Wikipedia: Arbor Day"
+      ]
+    },
+    {
+      "query": "\"space opera involving superhuman intelligences aliens variable\"",
+      "relevant_titles": [
+        "Wikipedia: A Fire Upon the Deep"
+      ]
+    },
+    {
+      "query": "\"first highly successful mass produced microcomputer products\"",
+      "relevant_titles": [
+        "Wikipedia: Apple II series"
+      ]
+    },
+    {
+      "query": "\"baptist preacher william miller first publicly shared\"",
+      "relevant_titles": [
+        "Wikipedia: Adventism"
+      ]
+    },
+    {
+      "query": "\"contrast digital computers represent varying quantities symbolically\"",
+      "relevant_titles": [
+        "Wikipedia: Analog computer"
+      ]
+    },
+    {
+      "query": "\"short sacred choral work still frequently seen\"",
+      "relevant_titles": [
+        "Wikipedia: Anthem"
+      ]
+    },
+    {
+      "query": "\"computer programs automated reasoning over mathematical proof\"",
+      "relevant_titles": [
+        "Wikipedia: Automated theorem proving"
+      ]
+    },
+    {
+      "query": "\"jeune aeacus also spelled eacus ancient greek\"",
+      "relevant_titles": [
+        "Wikipedia: Aeacus"
+      ]
+    },
+    {
+      "query": "\"analog mobile phone system standard originally developed\"",
+      "relevant_titles": [
+        "Wikipedia: Advanced Mobile Phone System"
+      ]
+    },
+    {
+      "query": "\"photography besides monitoring aircraft aircraft spotting enthusiasts\"",
+      "relevant_titles": [
+        "Wikipedia: Aircraft spotting"
+      ]
+    },
+    {
+      "query": "\"grid municipal water systems sewage treatment systems\"",
+      "relevant_titles": [
+        "Wikipedia: Autonomous building"
+      ]
+    },
+    {
+      "query": "\"resolve long standing issues surrounding aboriginal land\"",
+      "relevant_titles": [
+        "Wikipedia: Alaska Native Claims Settlement Act"
+      ]
+    },
+    {
+      "query": "\"amino acid located four residues earlier along\"",
+      "relevant_titles": [
+        "Wikipedia: Alpha helix"
+      ]
+    },
+    {
+      "query": "\"heavily armed long endurance ground attack variant\"",
+      "relevant_titles": [
+        "Wikipedia: Lockheed AC-130"
+      ]
+    },
+    {
+      "query": "\"malted barley though wheat maize corn rice\"",
+      "relevant_titles": [
+        "Wikipedia: Beer"
+      ]
+    },
+    {
+      "query": "\"also called computer bulletin board service cbbs\"",
+      "relevant_titles": [
+        "Wikipedia: Bulletin board system"
+      ]
+    },
+    {
+      "query": "\"motor powered pedal driven single track vehicle\"",
+      "relevant_titles": [
+        "Wikipedia: Bicycle"
+      ]
+    },
+    {
+      "query": "\"white blood cells store minerals provide structure\"",
+      "relevant_titles": [
+        "Wikipedia: Bone"
+      ]
+    },
+    {
+      "query": "\"boltzmann distribution also called gibbs distribution translated\"",
+      "relevant_titles": [
+        "Wikipedia: Boltzmann distribution"
+      ]
+    },
+    {
+      "query": "\"cornwall england united kingdom bodmin moor became\"",
+      "relevant_titles": [
+        "Wikipedia: Beast of Bodmin Moor"
+      ]
+    },
+    {
+      "query": "\"cisalpine gaul northern italy pannonia hungary parts\"",
+      "relevant_titles": [
+        "Wikipedia: Boii"
+      ]
+    },
+    {
+      "query": "\"penetrating dense anti aircraft defenses designed during\"",
+      "relevant_titles": [
+        "Wikipedia: Northrop Grumman B-2 Spirit"
+      ]
+    },
+    {
+      "query": "\"theory named after john bardeen leon cooper\"",
+      "relevant_titles": [
+        "Wikipedia: BCS theory"
+      ]
+    },
+    {
+      "query": "\"perceive such objects include landscapes sunsets humans\"",
+      "relevant_titles": [
+        "Wikipedia: Beauty"
+      ]
+    },
+    {
+      "query": "\"disorder manic depressive illness historical manic depressive\"",
+      "relevant_titles": [
+        "Wikipedia: Bipolar disorder"
+      ]
+    },
+    {
+      "query": "\"blues legends blind lemon jefferson world music\"",
+      "relevant_titles": [
+        "Wikipedia: Blind Lemon Jefferson"
+      ]
+    },
+    {
+      "query": "\"bacteria common symptoms include increased vaginal discharge\"",
+      "relevant_titles": [
+        "Wikipedia: Bacterial vaginosis"
+      ]
+    },
+    {
+      "query": "\"tactile braille cells using braille translation software\"",
+      "relevant_titles": [
+        "Wikipedia: Braille embosser"
+      ]
+    },
+    {
+      "query": "\"formation singing love songs marketed towards girls\"",
+      "relevant_titles": [
+        "Wikipedia: Boy band"
+      ]
+    },
+    {
+      "query": "\"boolean satisfiability problem sometimes called propositional satisfiability\"",
+      "relevant_titles": [
+        "Wikipedia: Boolean satisfiability problem"
+      ]
+    },
+    {
+      "query": "\"regular protein secondary structure beta sheets consist\"",
+      "relevant_titles": [
+        "Wikipedia: Beta sheet"
+      ]
+    },
+    {
+      "query": "\"largest privately held family owned spirits companies\"",
+      "relevant_titles": [
+        "Wikipedia: Bacardi"
+      ]
+    },
+    {
+      "query": "\"supersonic variable sweep wing heavy bomber used\"",
+      "relevant_titles": [
+        "Wikipedia: Rockwell B-1 Lancer"
+      ]
+    },
+    {
+      "query": "\"past telecommunications included telegraphy available through canadian\"",
+      "relevant_titles": [
+        "Wikipedia: Telecommunications in Canada"
+      ]
+    },
+    {
+      "query": "\"efficient high capacity multimodal transport spanning often\"",
+      "relevant_titles": [
+        "Wikipedia: Transportation in Canada"
+      ]
+    },
+    {
+      "query": "\"hotels resorts restaurants retail shopping cruise ships\"",
+      "relevant_titles": [
+        "Wikipedia: Casino"
+      ]
+    },
+    {
+      "query": "\"suspended throughout another substance however some definitions\"",
+      "relevant_titles": [
+        "Wikipedia: Colloid"
+      ]
+    }
+  ]
+}

--- a/internal/bench/testdata/queries.abstract1.abstract.json
+++ b/internal/bench/testdata/queries.abstract1.abstract.json
@@ -1,0 +1,16 @@
+{
+  "queries": [
+    {
+      "query": "\"conspiracy theory popularized by a 1995 memo\"",
+      "relevant_titles": ["Wikipedia: Vast right-wing conspiracy"]
+    },
+    {
+      "query": "\"application of science and engineering principles\"",
+      "relevant_titles": ["Wikipedia: Fire protection engineering"]
+    },
+    {
+      "query": "\"cold salty water found deep below the surface\"",
+      "relevant_titles": ["Wikipedia: Deep ocean water"]
+    }
+  ]
+}

--- a/internal/bench/testdata/queries.abstract1.title.50.json
+++ b/internal/bench/testdata/queries.abstract1.title.50.json
@@ -1,0 +1,304 @@
+{
+  "queries": [
+    {
+      "query": "\"abraham lincoln\"",
+      "relevant_titles": [
+        "Wikipedia: Abraham Lincoln"
+      ]
+    },
+    {
+      "query": "\"academy awards\"",
+      "relevant_titles": [
+        "Wikipedia: Academy Awards"
+      ]
+    },
+    {
+      "query": "\"international atomic time\"",
+      "relevant_titles": [
+        "Wikipedia: International Atomic Time"
+      ]
+    },
+    {
+      "query": "\"ayn rand\"",
+      "relevant_titles": [
+        "Wikipedia: Ayn Rand"
+      ]
+    },
+    {
+      "query": "\"alain connes\"",
+      "relevant_titles": [
+        "Wikipedia: Alain Connes"
+      ]
+    },
+    {
+      "query": "\"allan dwan\"",
+      "relevant_titles": [
+        "Wikipedia: Allan Dwan"
+      ]
+    },
+    {
+      "query": "\"agricultural science\"",
+      "relevant_titles": [
+        "Wikipedia: Agricultural science"
+      ]
+    },
+    {
+      "query": "\"andre agassi\"",
+      "relevant_titles": [
+        "Wikipedia: Andre Agassi"
+      ]
+    },
+    {
+      "query": "\"austroasiatic languages\"",
+      "relevant_titles": [
+        "Wikipedia: Austroasiatic languages"
+      ]
+    },
+    {
+      "query": "\"afroasiatic languages\"",
+      "relevant_titles": [
+        "Wikipedia: Afroasiatic languages"
+      ]
+    },
+    {
+      "query": "\"arithmetic mean\"",
+      "relevant_titles": [
+        "Wikipedia: Arithmetic mean"
+      ]
+    },
+    {
+      "query": "\"american football conference\"",
+      "relevant_titles": [
+        "Wikipedia: American Football Conference"
+      ]
+    },
+    {
+      "query": "\"animal farm\"",
+      "relevant_titles": [
+        "Wikipedia: Animal Farm"
+      ]
+    },
+    {
+      "query": "\"aldous huxley\"",
+      "relevant_titles": [
+        "Wikipedia: Aldous Huxley"
+      ]
+    },
+    {
+      "query": "\"appellate court\"",
+      "relevant_titles": [
+        "Wikipedia: Appellate court"
+      ]
+    },
+    {
+      "query": "\"assistive technology\"",
+      "relevant_titles": [
+        "Wikipedia: Assistive technology"
+      ]
+    },
+    {
+      "query": "\"american national standards institute\"",
+      "relevant_titles": [
+        "Wikipedia: American National Standards Institute"
+      ]
+    },
+    {
+      "query": "\"alkali metal\"",
+      "relevant_titles": [
+        "Wikipedia: Alkali metal"
+      ]
+    },
+    {
+      "query": "\"atomic number\"",
+      "relevant_titles": [
+        "Wikipedia: Atomic number"
+      ]
+    },
+    {
+      "query": "\"andrei tarkovsky\"",
+      "relevant_titles": [
+        "Wikipedia: Andrei Tarkovsky"
+      ]
+    },
+    {
+      "query": "\"atlantic ocean\"",
+      "relevant_titles": [
+        "Wikipedia: Atlantic Ocean"
+      ]
+    },
+    {
+      "query": "\"arthur schopenhauer\"",
+      "relevant_titles": [
+        "Wikipedia: Arthur Schopenhauer"
+      ]
+    },
+    {
+      "query": "\"angolan armed forces\"",
+      "relevant_titles": [
+        "Wikipedia: Angolan Armed Forces"
+      ]
+    },
+    {
+      "query": "\"albert sidney johnston\"",
+      "relevant_titles": [
+        "Wikipedia: Albert Sidney Johnston"
+      ]
+    },
+    {
+      "query": "\"albert einstein\"",
+      "relevant_titles": [
+        "Wikipedia: Albert Einstein"
+      ]
+    },
+    {
+      "query": "\"amateur astronomy\"",
+      "relevant_titles": [
+        "Wikipedia: Amateur astronomy"
+      ]
+    },
+    {
+      "query": "\"american revolutionary war\"",
+      "relevant_titles": [
+        "Wikipedia: American Revolutionary War"
+      ]
+    },
+    {
+      "query": "\"annual plant\"",
+      "relevant_titles": [
+        "Wikipedia: Annual plant"
+      ]
+    },
+    {
+      "query": "\"alfred korzybski\"",
+      "relevant_titles": [
+        "Wikipedia: Alfred Korzybski"
+      ]
+    },
+    {
+      "query": "\"alfred hitchcock\"",
+      "relevant_titles": [
+        "Wikipedia: Alfred Hitchcock"
+      ]
+    },
+    {
+      "query": "\"altaic languages\"",
+      "relevant_titles": [
+        "Wikipedia: Altaic languages"
+      ]
+    },
+    {
+      "query": "\"austrian german\"",
+      "relevant_titles": [
+        "Wikipedia: Austrian German"
+      ]
+    },
+    {
+      "query": "\"aegean sea\"",
+      "relevant_titles": [
+        "Wikipedia: Aegean Sea"
+      ]
+    },
+    {
+      "query": "\"alfred nobel\"",
+      "relevant_titles": [
+        "Wikipedia: Alfred Nobel"
+      ]
+    },
+    {
+      "query": "\"alexander graham bell\"",
+      "relevant_titles": [
+        "Wikipedia: Alexander Graham Bell"
+      ]
+    },
+    {
+      "query": "\"aztlan underground\"",
+      "relevant_titles": [
+        "Wikipedia: Aztlan Underground"
+      ]
+    },
+    {
+      "query": "\"american civil war\"",
+      "relevant_titles": [
+        "Wikipedia: American Civil War"
+      ]
+    },
+    {
+      "query": "\"andy warhol\"",
+      "relevant_titles": [
+        "Wikipedia: Andy Warhol"
+      ]
+    },
+    {
+      "query": "\"alp arslan\"",
+      "relevant_titles": [
+        "Wikipedia: Alp Arslan"
+      ]
+    },
+    {
+      "query": "\"american film institute\"",
+      "relevant_titles": [
+        "Wikipedia: American Film Institute"
+      ]
+    },
+    {
+      "query": "\"akira kurosawa\"",
+      "relevant_titles": [
+        "Wikipedia: Akira Kurosawa"
+      ]
+    },
+    {
+      "query": "\"ancient egypt\"",
+      "relevant_titles": [
+        "Wikipedia: Ancient Egypt"
+      ]
+    },
+    {
+      "query": "\"analog brothers\"",
+      "relevant_titles": [
+        "Wikipedia: Analog Brothers"
+      ]
+    },
+    {
+      "query": "\"motor neuron disease\"",
+      "relevant_titles": [
+        "Wikipedia: Motor neuron disease"
+      ]
+    },
+    {
+      "query": "\"anna kournikova\"",
+      "relevant_titles": [
+        "Wikipedia: Anna Kournikova"
+      ]
+    },
+    {
+      "query": "\"alfons maria jakob\"",
+      "relevant_titles": [
+        "Wikipedia: Alfons Maria Jakob"
+      ]
+    },
+    {
+      "query": "\"arable land\"",
+      "relevant_titles": [
+        "Wikipedia: Arable land"
+      ]
+    },
+    {
+      "query": "\"advanced chemistry\"",
+      "relevant_titles": [
+        "Wikipedia: Advanced Chemistry"
+      ]
+    },
+    {
+      "query": "\"anglican communion\"",
+      "relevant_titles": [
+        "Wikipedia: Anglican Communion"
+      ]
+    },
+    {
+      "query": "\"arne kaijser\"",
+      "relevant_titles": [
+        "Wikipedia: Arne Kaijser"
+      ]
+    }
+  ]
+}

--- a/internal/bench/testdata/queries.abstract1.title.json
+++ b/internal/bench/testdata/queries.abstract1.title.json
@@ -1,0 +1,16 @@
+{
+  "queries": [
+    {
+      "query": "canal du midi",
+      "relevant_titles": ["Wikipedia: Canal du Midi"]
+    },
+    {
+      "query": "barack obama",
+      "relevant_titles": ["Wikipedia: Barack Obama"]
+    },
+    {
+      "query": "climate change mitigation",
+      "relevant_titles": ["Wikipedia: Climate change mitigation"]
+    }
+  ]
+}

--- a/internal/domain/models/document.go
+++ b/internal/domain/models/document.go
@@ -19,8 +19,25 @@ type ResultData struct {
 	Document      Document `json:"document"`
 }
 
+type SearchDiagnostics struct {
+	LogicalQueryType   string            `json:"logical_query_type"`
+	ExecutionStrategy  string            `json:"execution_strategy"`
+	StrategySkipReason string            `json:"strategy_skip_reason"`
+	Timings            map[string]string `json:"timings"`
+	ProcessedTokens    int               `json:"processed_tokens"`
+	FieldsVisited      int               `json:"fields_visited"`
+	GeneratedKeys      int               `json:"generated_keys"`
+	IndexSearches      int               `json:"index_searches"`
+	FilterChecks       int               `json:"filter_checks"`
+	FilterRejects      int               `json:"filter_rejects"`
+	PostingEntriesRead int               `json:"posting_entries_read"`
+	CandidateDocs      int               `json:"candidate_docs"`
+	MatchedDocs        int               `json:"matched_docs"`
+	ReturnedDocs       int               `json:"returned_docs"`
+}
+
 type SearchResult struct {
 	ResultData        []ResultData
 	TotalResultsCount int
-	Timings           map[string]string
+	Diagnostics       *SearchDiagnostics
 }

--- a/pkg/fts/boolean_eval.go
+++ b/pkg/fts/boolean_eval.go
@@ -7,6 +7,9 @@ import (
 
 func (s *Service) execBoolean(ctx context.Context, q *BooleanQuery, candidateLimit int, scope queryFieldScope) (map[DocID]docAccum, error) {
 	if q == nil || len(q.Clauses) == 0 {
+		if exec := diagnosticsFromContext(ctx); exec != nil {
+			exec.setStrategy("empty")
+		}
 		return map[DocID]docAccum{}, nil
 	}
 
@@ -31,6 +34,9 @@ func (s *Service) execBoolean(ctx context.Context, q *BooleanQuery, candidateLim
 	var musts []map[DocID]docAccum
 	var shoulds []map[DocID]docAccum
 	exclude := make(map[DocID]struct{})
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.setStrategy("bool_fallback")
+	}
 
 	for _, clause := range q.Clauses {
 		if err := ctx.Err(); err != nil {

--- a/pkg/fts/boolean_eval.go
+++ b/pkg/fts/boolean_eval.go
@@ -8,7 +8,7 @@ import (
 func (s *Service) execBoolean(ctx context.Context, q *BooleanQuery, candidateLimit int, scope queryFieldScope) (map[DocID]docAccum, error) {
 	if q == nil || len(q.Clauses) == 0 {
 		if exec := diagnosticsFromContext(ctx); exec != nil {
-			exec.setStrategy("empty")
+			exec.setStrategy(strategyEmpty)
 		}
 		return map[DocID]docAccum{}, nil
 	}
@@ -35,7 +35,7 @@ func (s *Service) execBoolean(ctx context.Context, q *BooleanQuery, candidateLim
 	var shoulds []map[DocID]docAccum
 	exclude := make(map[DocID]struct{})
 	if exec := diagnosticsFromContext(ctx); exec != nil {
-		exec.setStrategy("bool_fallback")
+		exec.setStrategy(strategyBoolFallback)
 	}
 
 	for _, clause := range q.Clauses {

--- a/pkg/fts/boolean_fast.go
+++ b/pkg/fts/boolean_fast.go
@@ -54,7 +54,7 @@ func (m *fastMust) contains(id DocID) bool {
 	return false
 }
 
-func parseFastAndClauses(q *BooleanQuery) ([]TermQuery, []BoolClause, []BoolClause, bool) {
+func parseFastAndClauses(q *BooleanQuery) ([]TermQuery, []BoolClause, []BoolClause, bool, string) {
 	var mustTerms []TermQuery
 	var shoulds []BoolClause
 	var mustNots []BoolClause
@@ -66,7 +66,7 @@ func parseFastAndClauses(q *BooleanQuery) ([]TermQuery, []BoolClause, []BoolClau
 		case Must:
 			term, ok := termQueryOf(clause.Query)
 			if !ok {
-				return nil, nil, nil, false
+				return nil, nil, nil, false, "and_fast_non_term_clause"
 			}
 			mustTerms = append(mustTerms, term)
 		case Should:
@@ -76,12 +76,12 @@ func parseFastAndClauses(q *BooleanQuery) ([]TermQuery, []BoolClause, []BoolClau
 		}
 	}
 	if len(mustTerms) == 0 {
-		return nil, nil, nil, false
+		return nil, nil, nil, false, "and_fast_no_must_terms"
 	}
-	return mustTerms, shoulds, mustNots, true
+	return mustTerms, shoulds, mustNots, true, ""
 }
 
-func parseFastOrClauses(q *BooleanQuery) ([]TermQuery, []BoolClause, bool) {
+func parseFastOrClauses(q *BooleanQuery) ([]TermQuery, []BoolClause, bool, string) {
 	var shouldTerms []TermQuery
 	var mustNots []BoolClause
 	for _, clause := range q.Clauses {
@@ -90,11 +90,11 @@ func parseFastOrClauses(q *BooleanQuery) ([]TermQuery, []BoolClause, bool) {
 		}
 		switch clause.Occur {
 		case Must:
-			return nil, nil, false
+			return nil, nil, false, "or_fast_has_must_clause"
 		case Should:
 			term, ok := termQueryOf(clause.Query)
 			if !ok {
-				return nil, nil, false
+				return nil, nil, false, "or_fast_non_term_clause"
 			}
 			shouldTerms = append(shouldTerms, term)
 		case MustNot:
@@ -102,9 +102,9 @@ func parseFastOrClauses(q *BooleanQuery) ([]TermQuery, []BoolClause, bool) {
 		}
 	}
 	if len(shouldTerms) == 0 {
-		return nil, nil, false
+		return nil, nil, false, "or_fast_no_should_terms"
 	}
-	return shouldTerms, mustNots, true
+	return shouldTerms, mustNots, true, ""
 }
 
 func (s *Service) buildExcludeSet(ctx context.Context, clauses []BoolClause, scope queryFieldScope) (map[DocID]struct{}, error) {
@@ -155,9 +155,20 @@ func (s *Service) applyShouldClauseBoosts(ctx context.Context, combined map[DocI
 }
 
 func (s *Service) tryExecBooleanAndFast(ctx context.Context, q *BooleanQuery, scope queryFieldScope) (map[DocID]docAccum, bool, error) {
-	mustTerms, shoulds, mustNots, ok := parseFastAndClauses(q)
+	mustTerms, shoulds, mustNots, ok, reason := parseFastAndClauses(q)
 	if !ok {
+		if exec := diagnosticsFromContext(ctx); exec != nil {
+			exec.recordFastPathSkip(reason)
+			exec.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
+				b.AndFast.SkipReason = reason
+			})
+		}
 		return nil, false, nil
+	}
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
+			b.AndFast.Eligible = true
+		})
 	}
 
 	mustGroups, exhausted, err := s.collectFastMustGroups(ctx, mustTerms, scope)
@@ -178,16 +189,28 @@ func (s *Service) tryExecBooleanAndFast(ctx context.Context, q *BooleanQuery, sc
 		// Fast path: Seq ordinals are only comparable within one field index.
 		if exec := diagnosticsFromContext(ctx); exec != nil {
 			exec.setStrategy("bool_and_fast_sort_merge")
+			exec.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
+				b.AndFast.Used = true
+				b.AndFast.UsedSortMerge = true
+				b.AndFast.DriverGroupSize = mustGroups[0].totalDocs
+				b.AndFast.OtherGroupCount = len(mustGroups) - 1
+			})
 		}
 		return s.execBooleanAndSortMerge(mustGroups, shoulds, exclude, ctx, scope)
 	}
 	if exec := diagnosticsFromContext(ctx); exec != nil {
 		exec.setStrategy("bool_and_fast_driver")
+		exec.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
+			b.AndFast.Used = true
+			b.AndFast.DriverGroupSize = mustGroups[0].totalDocs
+			b.AndFast.OtherGroupCount = len(mustGroups) - 1
+		})
 	}
 
 	// Fallback path: use the smallest MUST group as the candidate driver when clauses expand to multiple lists.
 	driverGroup := &mustGroups[0]
 	otherGroups := mustGroups[1:]
+	builtLookupMaps := false
 	if driverGroup.totalDocs >= lookupMapThreshold {
 		// For larger candidate sets, prebuild lookup maps for the remaining MUST groups.
 		for i := range otherGroups {
@@ -195,6 +218,12 @@ func (s *Service) tryExecBooleanAndFast(ctx context.Context, q *BooleanQuery, sc
 				otherGroups[i].expansions[j].buildMap()
 			}
 		}
+		builtLookupMaps = len(otherGroups) > 0
+	}
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
+			b.AndFast.BuiltLookupMaps = builtLookupMaps
+		})
 	}
 
 	// Final AND matches keyed by DocID, with accumulated clause and term-frequency counts.
@@ -257,13 +286,21 @@ func (s *Service) tryExecBooleanAndFast(ctx context.Context, q *BooleanQuery, sc
 	if err := s.applyShouldClauseBoosts(ctx, combined, shoulds, scope); err != nil {
 		return nil, false, err
 	}
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
+			b.AndFast.CandidateDocs = len(combined)
+		})
+	}
 
 	return combined, true, nil
 }
 
 func (s *Service) tryExecBooleanOrFast(ctx context.Context, q *BooleanQuery, scope queryFieldScope) (map[DocID]docAccum, bool, error) {
-	shouldTerms, mustNots, ok := parseFastOrClauses(q)
+	shouldTerms, mustNots, ok, reason := parseFastOrClauses(q)
 	if !ok {
+		if exec := diagnosticsFromContext(ctx); exec != nil {
+			exec.recordFastPathSkip(reason)
+		}
 		return nil, false, nil
 	}
 	if exec := diagnosticsFromContext(ctx); exec != nil {
@@ -407,6 +444,11 @@ loop:
 
 	if err := s.applyShouldClauseBoosts(ctx, combined, shoulds, scope); err != nil {
 		return nil, false, err
+	}
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
+			b.AndFast.CandidateDocs = len(combined)
+		})
 	}
 
 	return combined, true, nil

--- a/pkg/fts/boolean_fast.go
+++ b/pkg/fts/boolean_fast.go
@@ -176,7 +176,13 @@ func (s *Service) tryExecBooleanAndFast(ctx context.Context, q *BooleanQuery, sc
 	sort.Slice(mustGroups, func(i, j int) bool { return mustGroups[i].totalDocs < mustGroups[j].totalDocs })
 	if allSingleExpansionInSameField(mustGroups) {
 		// Fast path: Seq ordinals are only comparable within one field index.
+		if exec := diagnosticsFromContext(ctx); exec != nil {
+			exec.setStrategy("bool_and_fast_sort_merge")
+		}
 		return s.execBooleanAndSortMerge(mustGroups, shoulds, exclude, ctx, scope)
+	}
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.setStrategy("bool_and_fast_driver")
 	}
 
 	// Fallback path: use the smallest MUST group as the candidate driver when clauses expand to multiple lists.
@@ -259,6 +265,9 @@ func (s *Service) tryExecBooleanOrFast(ctx context.Context, q *BooleanQuery, sco
 	shouldTerms, mustNots, ok := parseFastOrClauses(q)
 	if !ok {
 		return nil, false, nil
+	}
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.setStrategy("bool_or_fast")
 	}
 
 	exclude, err := s.buildExcludeSet(ctx, mustNots, scope)
@@ -415,10 +424,17 @@ func (s *Service) collectTermPostings(ctx context.Context, q TermQuery, scope qu
 	}
 
 	fields := s.resolveScopedFields(q.Field, scope)
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.addTokens(len(tokens))
+		exec.addFields(len(fields))
+	}
 	for _, token := range tokens {
 		keys, err := s.keyGen(token)
 		if err != nil {
 			return fastMust{}, err
+		}
+		if exec := diagnosticsFromContext(ctx); exec != nil {
+			exec.addKeys(len(keys))
 		}
 
 		for _, field := range fields {

--- a/pkg/fts/boolean_fast.go
+++ b/pkg/fts/boolean_fast.go
@@ -188,7 +188,7 @@ func (s *Service) tryExecBooleanAndFast(ctx context.Context, q *BooleanQuery, sc
 	if allSingleExpansionInSameField(mustGroups) {
 		// Fast path: Seq ordinals are only comparable within one field index.
 		if exec := diagnosticsFromContext(ctx); exec != nil {
-			exec.setStrategy("bool_and_fast_sort_merge")
+			exec.setStrategy(strategyBoolAndFastSortMerge)
 			exec.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
 				b.AndFast.Used = true
 				b.AndFast.UsedSortMerge = true
@@ -199,7 +199,7 @@ func (s *Service) tryExecBooleanAndFast(ctx context.Context, q *BooleanQuery, sc
 		return s.execBooleanAndSortMerge(mustGroups, shoulds, exclude, ctx, scope)
 	}
 	if exec := diagnosticsFromContext(ctx); exec != nil {
-		exec.setStrategy("bool_and_fast_driver")
+		exec.setStrategy(strategyBoolAndFastDriver)
 		exec.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
 			b.AndFast.Used = true
 			b.AndFast.DriverGroupSize = mustGroups[0].totalDocs
@@ -304,7 +304,7 @@ func (s *Service) tryExecBooleanOrFast(ctx context.Context, q *BooleanQuery, sco
 		return nil, false, nil
 	}
 	if exec := diagnosticsFromContext(ctx); exec != nil {
-		exec.setStrategy("bool_or_fast")
+		exec.setStrategy(strategyBoolOrFast)
 	}
 
 	exclude, err := s.buildExcludeSet(ctx, mustNots, scope)

--- a/pkg/fts/diagnostics.go
+++ b/pkg/fts/diagnostics.go
@@ -1,0 +1,243 @@
+package fts
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type QueryDiagnostics struct {
+	// LogicalQueryType describes the parsed logical query form: term, prefix, phrase, boolean, etc.
+	LogicalQueryType string
+	// ExecutionStrategy describes the physical execution path that was selected.
+	ExecutionStrategy string
+	// StrategyReason stores the first useful reason for strategy selection or fast-path skip.
+	StrategyReason string
+
+	// ProcessedTokens is the total number of tokens processed across the executed query path.
+	ProcessedTokens int
+	// FieldsVisited is the accumulated field fan-out across the executed query path.
+	FieldsVisited int
+	// GeneratedKeys is the total number of index keys generated from processed tokens.
+	GeneratedKeys int
+	// IndexSearches counts index/prefix/positional search calls executed by the query.
+	IndexSearches int
+	// FilterChecks counts membership checks against the optional filter.
+	FilterChecks int
+	// FilterRejects counts filter checks that rejected a key before index lookup.
+	FilterRejects int
+	// PostingEntriesRead counts posting/doc entries returned by low-level index lookups.
+	PostingEntriesRead int
+	// CandidateDocs is the number of documents materialized into the final hit set before top-k truncation.
+	CandidateDocs int
+	// MatchedDocs is the number of documents matched by the executed query after query evaluation.
+	MatchedDocs int
+	// ReturnedDocs is the number of documents returned to the caller after maxResults truncation.
+	ReturnedDocs int
+
+	// Timings stores per-stage durations for this query execution.
+	Timings map[string]time.Duration
+}
+
+type diagnosticsContextKey struct{}
+
+type queryExecContext struct {
+	mu sync.Mutex
+	d  QueryDiagnostics
+}
+
+func ensureDiagnosticsContext(ctx context.Context) (context.Context, *queryExecContext) {
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		return ctx, exec
+	}
+	exec := &queryExecContext{d: QueryDiagnostics{Timings: make(map[string]time.Duration)}}
+	return context.WithValue(ctx, diagnosticsContextKey{}, exec), exec
+}
+
+func diagnosticsFromContext(ctx context.Context) *queryExecContext {
+	if ctx == nil {
+		return nil
+	}
+	exec, _ := ctx.Value(diagnosticsContextKey{}).(*queryExecContext)
+	return exec
+}
+
+func attachDiagnostics(ctx context.Context, res *SearchResult) *SearchResult {
+	if res == nil {
+		return nil
+	}
+	exec := diagnosticsFromContext(ctx)
+	if exec == nil {
+		return res
+	}
+	exec.setCandidateDocs(res.TotalResultsCount)
+	exec.setMatchedDocs(res.TotalResultsCount)
+	exec.setReturnedDocs(len(res.Results))
+	res.Diagnostics = exec.snapshot()
+	return res
+}
+
+func (q *queryExecContext) snapshot() *QueryDiagnostics {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	copyD := q.d
+	copyD.Timings = copyDurationMap(q.d.Timings)
+	return &copyD
+}
+
+func copyDurationMap(src map[string]time.Duration) map[string]time.Duration {
+	if len(src) == 0 {
+		return map[string]time.Duration{}
+	}
+	out := make(map[string]time.Duration, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}
+
+func (q *queryExecContext) setQueryTypeIfEmpty(v string) {
+	if q == nil || v == "" {
+		return
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.d.LogicalQueryType == "" {
+		q.d.LogicalQueryType = v
+	}
+}
+
+func (q *queryExecContext) setStrategy(v string) {
+	if q == nil || v == "" {
+		return
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.d.ExecutionStrategy == "" {
+		q.d.ExecutionStrategy = v
+	}
+}
+
+func (q *queryExecContext) setReasonIfEmpty(v string) {
+	if q == nil || v == "" {
+		return
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.d.StrategyReason == "" {
+		q.d.StrategyReason = v
+	}
+}
+
+func (q *queryExecContext) addTokens(n int) {
+	if q == nil || n == 0 {
+		return
+	}
+	q.mu.Lock()
+	q.d.ProcessedTokens += n
+	q.mu.Unlock()
+}
+
+func (q *queryExecContext) addFields(n int) {
+	if q == nil || n == 0 {
+		return
+	}
+	q.mu.Lock()
+	q.d.FieldsVisited += n
+	q.mu.Unlock()
+}
+
+func (q *queryExecContext) addKeys(n int) {
+	if q == nil || n == 0 {
+		return
+	}
+	q.mu.Lock()
+	q.d.GeneratedKeys += n
+	q.mu.Unlock()
+}
+
+func (q *queryExecContext) addIndexLookups(n int) {
+	if q == nil || n == 0 {
+		return
+	}
+	q.mu.Lock()
+	q.d.IndexSearches += n
+	q.mu.Unlock()
+}
+
+func (q *queryExecContext) addFilterCheck(missed bool) {
+	if q == nil {
+		return
+	}
+	q.mu.Lock()
+	q.d.FilterChecks++
+	if missed {
+		q.d.FilterRejects++
+	}
+	q.mu.Unlock()
+}
+
+func (q *queryExecContext) addPostingsRead(n int) {
+	if q == nil || n == 0 {
+		return
+	}
+	q.mu.Lock()
+	q.d.PostingEntriesRead += n
+	q.mu.Unlock()
+}
+
+func (q *queryExecContext) setCandidateDocs(n int) {
+	if q == nil {
+		return
+	}
+	q.mu.Lock()
+	q.d.CandidateDocs = n
+	q.mu.Unlock()
+}
+
+func (q *queryExecContext) setMatchedDocs(n int) {
+	if q == nil {
+		return
+	}
+	q.mu.Lock()
+	q.d.MatchedDocs = n
+	q.mu.Unlock()
+}
+
+func (q *queryExecContext) setReturnedDocs(n int) {
+	if q == nil {
+		return
+	}
+	q.mu.Lock()
+	q.d.ReturnedDocs = n
+	q.mu.Unlock()
+}
+
+func (q *queryExecContext) addTiming(name string, d time.Duration) {
+	if q == nil || name == "" {
+		return
+	}
+	q.mu.Lock()
+	q.d.Timings[name] = d
+	q.mu.Unlock()
+}
+
+func queryTypeOf(q Query) string {
+	switch t := q.(type) {
+	case nil:
+		return "empty"
+	case TermQuery, *TermQuery:
+		return "term"
+	case PhraseQuery, *PhraseQuery:
+		return "phrase"
+	case PrefixQuery, *PrefixQuery:
+		return "prefix"
+	case *BooleanQuery:
+		if t == nil || len(t.Clauses) == 0 {
+			return "empty"
+		}
+		return "boolean"
+	default:
+		return "unsupported"
+	}
+}

--- a/pkg/fts/diagnostics.go
+++ b/pkg/fts/diagnostics.go
@@ -246,14 +246,20 @@ func (q *queryExecContext) addIndexLookups(n int) {
 }
 
 func (q *queryExecContext) addFilterCheck(missed bool) {
-	if q == nil {
+	rejects := 0
+	if missed {
+		rejects = 1
+	}
+	q.addFilterChecks(1, rejects)
+}
+
+func (q *queryExecContext) addFilterChecks(total, rejects int) {
+	if q == nil || total == 0 {
 		return
 	}
 	q.mu.Lock()
-	q.d.FilterChecks++
-	if missed {
-		q.d.FilterRejects++
-	}
+	q.d.FilterChecks += total
+	q.d.FilterRejects += rejects
 	q.mu.Unlock()
 }
 

--- a/pkg/fts/diagnostics.go
+++ b/pkg/fts/diagnostics.go
@@ -11,8 +11,10 @@ type QueryDiagnostics struct {
 	LogicalQueryType string
 	// ExecutionStrategy describes the physical execution path that was selected.
 	ExecutionStrategy string
-	// StrategyReason stores the first useful reason for strategy selection or fast-path skip.
-	StrategyReason string
+	// StrategySkipReason stores the first useful reason why an earlier strategy or fast path was skipped.
+	StrategySkipReason string
+	// Boolean stores strategy-specific diagnostics for boolean execution paths.
+	Boolean *BooleanDiagnostics
 
 	// ProcessedTokens is the total number of tokens processed across the executed query path.
 	ProcessedTokens int
@@ -37,6 +39,37 @@ type QueryDiagnostics struct {
 
 	// Timings stores per-stage durations for this query execution.
 	Timings map[string]time.Duration
+}
+
+type BooleanDiagnostics struct {
+	FastPathSkips       int
+	FastPathSkipReasons []string
+	WAND                WANDDiagnostics
+	AndFast             AndFastDiagnostics
+}
+
+type WANDDiagnostics struct {
+	Eligible           bool
+	Used               bool
+	SkipReason         string
+	ClauseCount        int
+	PostingsPerClause  []int
+	PostingsConsidered int
+	CandidateDocs      int
+	HeapSize           int
+	TopK               int
+	FinalTheta         float64
+}
+
+type AndFastDiagnostics struct {
+	Eligible        bool
+	Used            bool
+	SkipReason      string
+	DriverGroupSize int
+	OtherGroupCount int
+	CandidateDocs   int
+	UsedSortMerge   bool
+	BuiltLookupMaps bool
 }
 
 type diagnosticsContextKey struct{}
@@ -81,8 +114,19 @@ func (q *queryExecContext) snapshot() *QueryDiagnostics {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	copyD := q.d
+	copyD.Boolean = copyBooleanDiagnostics(q.d.Boolean)
 	copyD.Timings = copyDurationMap(q.d.Timings)
 	return &copyD
+}
+
+func copyBooleanDiagnostics(src *BooleanDiagnostics) *BooleanDiagnostics {
+	if src == nil {
+		return nil
+	}
+	out := *src
+	out.FastPathSkipReasons = append([]string(nil), src.FastPathSkipReasons...)
+	out.WAND.PostingsPerClause = append([]int(nil), src.WAND.PostingsPerClause...)
+	return &out
 }
 
 func copyDurationMap(src map[string]time.Duration) map[string]time.Duration {
@@ -118,14 +162,14 @@ func (q *queryExecContext) setStrategy(v string) {
 	}
 }
 
-func (q *queryExecContext) setReasonIfEmpty(v string) {
+func (q *queryExecContext) setSkipReasonIfEmpty(v string) {
 	if q == nil || v == "" {
 		return
 	}
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	if q.d.StrategyReason == "" {
-		q.d.StrategyReason = v
+	if q.d.StrategySkipReason == "" {
+		q.d.StrategySkipReason = v
 	}
 }
 
@@ -220,6 +264,27 @@ func (q *queryExecContext) addTiming(name string, d time.Duration) {
 	q.mu.Lock()
 	q.d.Timings[name] = d
 	q.mu.Unlock()
+}
+
+func (q *queryExecContext) updateBooleanDiagnostics(fn func(*BooleanDiagnostics)) {
+	if q == nil || fn == nil {
+		return
+	}
+	q.mu.Lock()
+	if q.d.Boolean == nil {
+		q.d.Boolean = &BooleanDiagnostics{}
+	}
+	fn(q.d.Boolean)
+	q.mu.Unlock()
+}
+
+func (q *queryExecContext) recordFastPathSkip(reason string) {
+	q.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
+		b.FastPathSkips++
+		if reason != "" {
+			b.FastPathSkipReasons = append(b.FastPathSkipReasons, reason)
+		}
+	})
 }
 
 func queryTypeOf(q Query) string {

--- a/pkg/fts/diagnostics.go
+++ b/pkg/fts/diagnostics.go
@@ -69,6 +69,23 @@ func (t QueryTimings) HasTotal() bool {
 	return t.set&queryTimingTotal != 0
 }
 
+type diagnosticsEnabledContextKey struct{}
+
+func WithDiagnostics(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, diagnosticsEnabledContextKey{}, true)
+}
+
+func diagnosticsRequested(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	enabled, _ := ctx.Value(diagnosticsEnabledContextKey{}).(bool)
+	return enabled
+}
+
 type BooleanDiagnostics struct {
 	FastPathSkips       int
 	FastPathSkipReasons []string
@@ -110,6 +127,9 @@ type queryExecContext struct {
 func ensureDiagnosticsContext(ctx context.Context) (context.Context, *queryExecContext) {
 	if exec := diagnosticsFromContext(ctx); exec != nil {
 		return ctx, exec
+	}
+	if !diagnosticsRequested(ctx) {
+		return ctx, nil
 	}
 	exec := &queryExecContext{}
 	return context.WithValue(ctx, diagnosticsContextKey{}, exec), exec
@@ -301,6 +321,34 @@ func (q *queryExecContext) setTotalTiming(d time.Duration) {
 	q.d.Timings.Total = d
 	q.d.Timings.set |= queryTimingTotal
 	q.mu.Unlock()
+}
+
+func (q *queryExecContext) startTimer() time.Time {
+	if q == nil {
+		return time.Time{}
+	}
+	return time.Now()
+}
+
+func (q *queryExecContext) observePreprocess(start time.Time) {
+	if q == nil || start.IsZero() {
+		return
+	}
+	q.setPreprocessTiming(time.Since(start))
+}
+
+func (q *queryExecContext) observeSearchTokens(start time.Time) {
+	if q == nil || start.IsZero() {
+		return
+	}
+	q.setSearchTokensTiming(time.Since(start))
+}
+
+func (q *queryExecContext) observeTotal(start time.Time) {
+	if q == nil || start.IsZero() {
+		return
+	}
+	q.setTotalTiming(time.Since(start))
 }
 
 func (q *queryExecContext) updateBooleanDiagnostics(fn func(*BooleanDiagnostics)) {

--- a/pkg/fts/diagnostics.go
+++ b/pkg/fts/diagnostics.go
@@ -57,6 +57,19 @@ const (
 	queryTimingTotal
 )
 
+const (
+	strategyEmpty                = "empty"
+	strategyTerm                 = "term"
+	strategyPrefix               = "prefix"
+	strategyPhraseExact          = "phrase_exact"
+	strategyPhraseNear           = "phrase_near"
+	strategyBoolFallback         = "bool_fallback"
+	strategyBoolOrWAND           = "bool_or_wand"
+	strategyBoolOrFast           = "bool_or_fast"
+	strategyBoolAndFastDriver    = "bool_and_fast_driver"
+	strategyBoolAndFastSortMerge = "bool_and_fast_sort_merge"
+)
+
 func (t QueryTimings) HasPreprocess() bool {
 	return t.set&queryTimingPreprocess != 0
 }

--- a/pkg/fts/diagnostics.go
+++ b/pkg/fts/diagnostics.go
@@ -38,7 +38,35 @@ type QueryDiagnostics struct {
 	ReturnedDocs int
 
 	// Timings stores per-stage durations for this query execution.
-	Timings map[string]time.Duration
+	Timings QueryTimings
+}
+
+type QueryTimings struct {
+	Preprocess   time.Duration
+	SearchTokens time.Duration
+	Total        time.Duration
+
+	set queryTimingMask
+}
+
+type queryTimingMask uint8
+
+const (
+	queryTimingPreprocess queryTimingMask = 1 << iota
+	queryTimingSearchTokens
+	queryTimingTotal
+)
+
+func (t QueryTimings) HasPreprocess() bool {
+	return t.set&queryTimingPreprocess != 0
+}
+
+func (t QueryTimings) HasSearchTokens() bool {
+	return t.set&queryTimingSearchTokens != 0
+}
+
+func (t QueryTimings) HasTotal() bool {
+	return t.set&queryTimingTotal != 0
 }
 
 type BooleanDiagnostics struct {
@@ -83,7 +111,7 @@ func ensureDiagnosticsContext(ctx context.Context) (context.Context, *queryExecC
 	if exec := diagnosticsFromContext(ctx); exec != nil {
 		return ctx, exec
 	}
-	exec := &queryExecContext{d: QueryDiagnostics{Timings: make(map[string]time.Duration)}}
+	exec := &queryExecContext{}
 	return context.WithValue(ctx, diagnosticsContextKey{}, exec), exec
 }
 
@@ -115,7 +143,6 @@ func (q *queryExecContext) snapshot() *QueryDiagnostics {
 	defer q.mu.Unlock()
 	copyD := q.d
 	copyD.Boolean = copyBooleanDiagnostics(q.d.Boolean)
-	copyD.Timings = copyDurationMap(q.d.Timings)
 	return &copyD
 }
 
@@ -127,17 +154,6 @@ func copyBooleanDiagnostics(src *BooleanDiagnostics) *BooleanDiagnostics {
 	out.FastPathSkipReasons = append([]string(nil), src.FastPathSkipReasons...)
 	out.WAND.PostingsPerClause = append([]int(nil), src.WAND.PostingsPerClause...)
 	return &out
-}
-
-func copyDurationMap(src map[string]time.Duration) map[string]time.Duration {
-	if len(src) == 0 {
-		return map[string]time.Duration{}
-	}
-	out := make(map[string]time.Duration, len(src))
-	for k, v := range src {
-		out[k] = v
-	}
-	return out
 }
 
 func (q *queryExecContext) setQueryTypeIfEmpty(v string) {
@@ -257,12 +273,33 @@ func (q *queryExecContext) setReturnedDocs(n int) {
 	q.mu.Unlock()
 }
 
-func (q *queryExecContext) addTiming(name string, d time.Duration) {
-	if q == nil || name == "" {
+func (q *queryExecContext) setPreprocessTiming(d time.Duration) {
+	if q == nil {
 		return
 	}
 	q.mu.Lock()
-	q.d.Timings[name] = d
+	q.d.Timings.Preprocess = d
+	q.d.Timings.set |= queryTimingPreprocess
+	q.mu.Unlock()
+}
+
+func (q *queryExecContext) setSearchTokensTiming(d time.Duration) {
+	if q == nil {
+		return
+	}
+	q.mu.Lock()
+	q.d.Timings.SearchTokens = d
+	q.d.Timings.set |= queryTimingSearchTokens
+	q.mu.Unlock()
+}
+
+func (q *queryExecContext) setTotalTiming(d time.Duration) {
+	if q == nil {
+		return
+	}
+	q.mu.Lock()
+	q.d.Timings.Total = d
+	q.d.Timings.set |= queryTimingTotal
 	q.mu.Unlock()
 }
 

--- a/pkg/fts/diagnostics_test.go
+++ b/pkg/fts/diagnostics_test.go
@@ -2,6 +2,7 @@ package fts
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -105,6 +106,30 @@ func TestSearchDiagnosticsBooleanOrWandStrategy(t *testing.T) {
 	if d.ReturnedDocs != 2 {
 		t.Fatalf("ReturnedDocs = %d, want 2", d.ReturnedDocs)
 	}
+	if d.Boolean == nil {
+		t.Fatal("expected boolean diagnostics")
+	}
+	if d.Boolean.FastPathSkips != 1 {
+		t.Fatalf("FastPathSkips = %d, want 1", d.Boolean.FastPathSkips)
+	}
+	if len(d.Boolean.FastPathSkipReasons) != 1 || d.Boolean.FastPathSkipReasons[0] != "and_fast_no_must_terms" {
+		t.Fatalf("FastPathSkipReasons = %v, want [and_fast_no_must_terms]", d.Boolean.FastPathSkipReasons)
+	}
+	if !d.Boolean.WAND.Eligible || !d.Boolean.WAND.Used {
+		t.Fatalf("unexpected WAND diagnostics: %+v", d.Boolean.WAND)
+	}
+	if d.Boolean.WAND.ClauseCount != 3 {
+		t.Fatalf("WAND ClauseCount = %d, want 3", d.Boolean.WAND.ClauseCount)
+	}
+	if d.Boolean.WAND.TopK != 2 || d.Boolean.WAND.HeapSize != 2 {
+		t.Fatalf("unexpected WAND topK/heap diagnostics: %+v", d.Boolean.WAND)
+	}
+	if len(d.Boolean.WAND.PostingsPerClause) != 3 {
+		t.Fatalf("WAND PostingsPerClause len = %d, want 3", len(d.Boolean.WAND.PostingsPerClause))
+	}
+	if d.Boolean.WAND.CandidateDocs <= 0 || d.Boolean.WAND.PostingsConsidered <= 0 {
+		t.Fatalf("expected positive WAND work counters, got %+v", d.Boolean.WAND)
+	}
 }
 
 func TestSearchDiagnosticsPhraseStrategy(t *testing.T) {
@@ -145,8 +170,8 @@ func TestSearchDiagnosticsBooleanFallbackStrategy(t *testing.T) {
 	if d.ExecutionStrategy != "bool_fallback" {
 		t.Fatalf("ExecutionStrategy = %q, want bool_fallback", d.ExecutionStrategy)
 	}
-	if d.StrategyReason != "wand_not_or_terms_only" {
-		t.Fatalf("StrategyReason = %q, want wand_not_or_terms_only", d.StrategyReason)
+	if d.StrategySkipReason != "wand_not_or_terms_only" {
+		t.Fatalf("StrategySkipReason = %q, want wand_not_or_terms_only", d.StrategySkipReason)
 	}
 }
 
@@ -167,6 +192,69 @@ func TestSearchDiagnosticsBooleanAndFastStrategy(t *testing.T) {
 	}
 	if d.ExecutionStrategy != "bool_and_fast_sort_merge" {
 		t.Fatalf("ExecutionStrategy = %q, want bool_and_fast_sort_merge", d.ExecutionStrategy)
+	}
+	if d.Boolean == nil {
+		t.Fatal("expected boolean diagnostics")
+	}
+	if !d.Boolean.AndFast.Eligible || !d.Boolean.AndFast.Used || !d.Boolean.AndFast.UsedSortMerge {
+		t.Fatalf("unexpected AND fast diagnostics: %+v", d.Boolean.AndFast)
+	}
+	if d.Boolean.AndFast.DriverGroupSize != 1 || d.Boolean.AndFast.OtherGroupCount != 1 {
+		t.Fatalf("unexpected AND fast group diagnostics: %+v", d.Boolean.AndFast)
+	}
+	if d.Boolean.AndFast.BuiltLookupMaps {
+		t.Fatalf("sort-merge path should not build lookup maps: %+v", d.Boolean.AndFast)
+	}
+	if d.Boolean.AndFast.CandidateDocs != 1 {
+		t.Fatalf("AndFast CandidateDocs = %d, want 1", d.Boolean.AndFast.CandidateDocs)
+	}
+}
+
+func TestSearchDiagnosticsBooleanAndFastDriverInstrumentation(t *testing.T) {
+	title := newMemoryIndex()
+	body := newMemoryIndex()
+	alphaDocs := make([]DocRef, 0, 60)
+	betaDocs := make([]DocRef, 0, 60)
+	for i := 0; i < 60; i++ {
+		id := DocID(fmt.Sprintf("doc-%d", i))
+		alphaDocs = append(alphaDocs, DocRef{ID: id, Count: 1, Seq: uint32(i + 1)})
+		betaDocs = append(betaDocs, DocRef{ID: id, Count: 1, Seq: uint32(i + 1)})
+	}
+	title.entries["alpha"] = alphaDocs
+	body.entries["beta"] = betaDocs
+
+	svc := NewMultiFieldFromIndexes(map[string]Index{
+		"title": title,
+		"body":  body,
+	}, WordKeys)
+
+	q := &BooleanQuery{Clauses: []BoolClause{
+		MustClause(TermQuery{Field: "title", Term: "alpha"}),
+		MustClause(TermQuery{Field: "body", Term: "beta"}),
+	}}
+
+	res, err := svc.Search(context.Background(), q, 10)
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	d := requireDiagnostics(t, res)
+	if d.ExecutionStrategy != "bool_and_fast_driver" {
+		t.Fatalf("ExecutionStrategy = %q, want bool_and_fast_driver", d.ExecutionStrategy)
+	}
+	if d.Boolean == nil {
+		t.Fatal("expected boolean diagnostics")
+	}
+	if !d.Boolean.AndFast.Eligible || !d.Boolean.AndFast.Used || d.Boolean.AndFast.UsedSortMerge {
+		t.Fatalf("unexpected AND fast driver diagnostics: %+v", d.Boolean.AndFast)
+	}
+	if !d.Boolean.AndFast.BuiltLookupMaps {
+		t.Fatalf("expected lookup maps to be built: %+v", d.Boolean.AndFast)
+	}
+	if d.Boolean.AndFast.DriverGroupSize != 60 || d.Boolean.AndFast.OtherGroupCount != 1 {
+		t.Fatalf("unexpected AND fast driver groups: %+v", d.Boolean.AndFast)
+	}
+	if d.Boolean.AndFast.CandidateDocs != 60 {
+		t.Fatalf("AndFast CandidateDocs = %d, want 60", d.Boolean.AndFast.CandidateDocs)
 	}
 }
 
@@ -192,8 +280,20 @@ func TestSearchDiagnosticsWandSkipReasonWithoutScorer(t *testing.T) {
 	if d.ExecutionStrategy != "bool_or_fast" {
 		t.Fatalf("ExecutionStrategy = %q, want bool_or_fast", d.ExecutionStrategy)
 	}
-	if d.StrategyReason != "wand_disabled_no_scorer" {
-		t.Fatalf("StrategyReason = %q, want wand_disabled_no_scorer", d.StrategyReason)
+	if d.StrategySkipReason != "wand_disabled_no_scorer" {
+		t.Fatalf("StrategySkipReason = %q, want wand_disabled_no_scorer", d.StrategySkipReason)
+	}
+	if d.Boolean == nil {
+		t.Fatal("expected boolean diagnostics")
+	}
+	if d.Boolean.FastPathSkips != 2 {
+		t.Fatalf("FastPathSkips = %d, want 2", d.Boolean.FastPathSkips)
+	}
+	if len(d.Boolean.FastPathSkipReasons) != 2 || d.Boolean.FastPathSkipReasons[1] != "wand_disabled_no_scorer" {
+		t.Fatalf("unexpected FastPathSkipReasons: %v", d.Boolean.FastPathSkipReasons)
+	}
+	if d.Boolean.WAND.Eligible || d.Boolean.WAND.Used || d.Boolean.WAND.SkipReason != "wand_disabled_no_scorer" {
+		t.Fatalf("unexpected WAND skip diagnostics: %+v", d.Boolean.WAND)
 	}
 }
 

--- a/pkg/fts/diagnostics_test.go
+++ b/pkg/fts/diagnostics_test.go
@@ -7,6 +7,10 @@ import (
 	"time"
 )
 
+func diagnosticsContext() context.Context {
+	return WithDiagnostics(context.Background())
+}
+
 func requireDiagnostics(t *testing.T, res *SearchResult) *QueryDiagnostics {
 	t.Helper()
 	if res == nil {
@@ -24,7 +28,7 @@ func requireDiagnostics(t *testing.T, res *SearchResult) *QueryDiagnostics {
 func TestSearchDiagnosticsTermStrategy(t *testing.T) {
 	svc := buildExecService(t)
 
-	res, err := svc.Search(context.Background(), TermQuery{Term: "barack"}, 10)
+	res, err := svc.Search(diagnosticsContext(), TermQuery{Term: "barack"}, 10)
 	if err != nil {
 		t.Fatalf("Search() error = %v", err)
 	}
@@ -55,7 +59,7 @@ func TestSearchDiagnosticsTermStrategy(t *testing.T) {
 func TestSearchDiagnosticsPrefixStrategy(t *testing.T) {
 	svc := buildExecService(t)
 
-	res, err := svc.Search(context.Background(), PrefixQuery{Field: "title", Prefix: "ba"}, 10)
+	res, err := svc.Search(diagnosticsContext(), PrefixQuery{Field: "title", Prefix: "ba"}, 10)
 	if err != nil {
 		t.Fatalf("Search() error = %v", err)
 	}
@@ -92,7 +96,7 @@ func TestSearchDiagnosticsBooleanOrWandStrategy(t *testing.T) {
 		ShouldClause(TermQuery{Term: "gamma"}),
 	}}
 
-	res, err := svc.Search(context.Background(), q, 2)
+	res, err := svc.Search(diagnosticsContext(), q, 2)
 	if err != nil {
 		t.Fatalf("Search() error = %v", err)
 	}
@@ -135,7 +139,7 @@ func TestSearchDiagnosticsBooleanOrWandStrategy(t *testing.T) {
 func TestSearchDiagnosticsPhraseStrategy(t *testing.T) {
 	svc := buildExecService(t)
 
-	res, err := svc.Search(context.Background(), PhraseQuery{Phrase: "barack obama"}, 10)
+	res, err := svc.Search(diagnosticsContext(), PhraseQuery{Phrase: "barack obama"}, 10)
 	if err != nil {
 		t.Fatalf("Search() error = %v", err)
 	}
@@ -159,7 +163,7 @@ func TestSearchDiagnosticsBooleanFallbackStrategy(t *testing.T) {
 		ShouldClause(TermQuery{Term: "banana"}),
 	}}
 
-	res, err := svc.Search(context.Background(), q, 10)
+	res, err := svc.Search(diagnosticsContext(), q, 10)
 	if err != nil {
 		t.Fatalf("Search() error = %v", err)
 	}
@@ -182,7 +186,7 @@ func TestSearchDiagnosticsBooleanAndFastStrategy(t *testing.T) {
 		MustClause(TermQuery{Field: "body", Term: "mars"}),
 	}}
 
-	res, err := svc.Search(context.Background(), q, 10)
+	res, err := svc.Search(diagnosticsContext(), q, 10)
 	if err != nil {
 		t.Fatalf("Search() error = %v", err)
 	}
@@ -233,7 +237,7 @@ func TestSearchDiagnosticsBooleanAndFastDriverInstrumentation(t *testing.T) {
 		MustClause(TermQuery{Field: "body", Term: "beta"}),
 	}}
 
-	res, err := svc.Search(context.Background(), q, 10)
+	res, err := svc.Search(diagnosticsContext(), q, 10)
 	if err != nil {
 		t.Fatalf("Search() error = %v", err)
 	}
@@ -269,7 +273,7 @@ func TestSearchDiagnosticsWandSkipReasonWithoutScorer(t *testing.T) {
 		ShouldClause(TermQuery{Term: "beta"}),
 	}}
 
-	res, err := svc.Search(context.Background(), q, 1)
+	res, err := svc.Search(diagnosticsContext(), q, 1)
 	if err != nil {
 		t.Fatalf("Search() error = %v", err)
 	}
@@ -300,7 +304,7 @@ func TestSearchDiagnosticsWandSkipReasonWithoutScorer(t *testing.T) {
 func TestSearchDocumentsDiagnosticsNonNil(t *testing.T) {
 	svc := buildExecService(t)
 
-	res, err := svc.SearchDocuments(context.Background(), "barack", 10)
+	res, err := svc.SearchDocuments(diagnosticsContext(), "barack", 10)
 	if err != nil {
 		t.Fatalf("SearchDocuments() error = %v", err)
 	}
@@ -316,7 +320,7 @@ func TestSearchDocumentsDiagnosticsNonNil(t *testing.T) {
 func TestSearchFieldClausesDiagnosticsNonNil(t *testing.T) {
 	svc := buildExecService(t)
 
-	res, err := svc.SearchFieldClauses(context.Background(), []FieldQueryClause{
+	res, err := svc.SearchFieldClauses(diagnosticsContext(), []FieldQueryClause{
 		MustFieldQuery("title", "barack"),
 		MustNotFieldQuery("body", "russia"),
 	}, 10)
@@ -334,7 +338,7 @@ func TestSearchFieldClausesDiagnosticsNonNil(t *testing.T) {
 
 func TestSearchPhrasePublicMethodsDiagnosticsNonNil(t *testing.T) {
 	svc := buildExecService(t)
-	ctx := context.Background()
+	ctx := diagnosticsContext()
 
 	cases := []struct {
 		name string
@@ -365,7 +369,7 @@ func TestSearchPhrasePublicMethodsDiagnosticsNonNil(t *testing.T) {
 
 func TestSearchPhraseNearPublicMethodsDiagnosticsNonNil(t *testing.T) {
 	svc := buildExecService(t)
-	ctx := context.Background()
+	ctx := diagnosticsContext()
 
 	cases := []struct {
 		name string

--- a/pkg/fts/diagnostics_test.go
+++ b/pkg/fts/diagnostics_test.go
@@ -15,8 +15,8 @@ func requireDiagnostics(t *testing.T, res *SearchResult) *QueryDiagnostics {
 	if res.Diagnostics == nil {
 		t.Fatal("expected non-nil Diagnostics")
 	}
-	if res.Diagnostics.Timings["total"] <= 0 {
-		t.Fatalf("expected Diagnostics.Timings[total] > 0, got %v", res.Diagnostics.Timings["total"])
+	if res.Diagnostics.Timings.Total <= 0 {
+		t.Fatalf("expected Diagnostics.Timings.Total > 0, got %v", res.Diagnostics.Timings.Total)
 	}
 	return res.Diagnostics
 }
@@ -44,10 +44,10 @@ func TestSearchDiagnosticsTermStrategy(t *testing.T) {
 	if d.ProcessedTokens <= 0 || d.IndexSearches <= 0 || d.PostingEntriesRead <= 0 {
 		t.Fatalf("expected positive token/lookups/postings metrics, got %+v", *d)
 	}
-	if d.Timings["search_tokens"] <= 0 || d.Timings["total"] < d.Timings["search_tokens"] {
+	if d.Timings.SearchTokens <= 0 || d.Timings.Total < d.Timings.SearchTokens {
 		t.Fatalf("unexpected timings: %+v", d.Timings)
 	}
-	if d.Timings["total"] > 10*time.Second {
+	if d.Timings.Total > 10*time.Second {
 		t.Fatalf("unexpectedly large timing: %+v", d.Timings)
 	}
 }
@@ -308,7 +308,7 @@ func TestSearchDocumentsDiagnosticsNonNil(t *testing.T) {
 	if d.LogicalQueryType != "term" {
 		t.Fatalf("LogicalQueryType = %q, want term", d.LogicalQueryType)
 	}
-	if d.Timings["preprocess"] <= 0 {
+	if d.Timings.Preprocess <= 0 {
 		t.Fatalf("expected preprocess timing > 0, got %+v", d.Timings)
 	}
 }
@@ -327,7 +327,7 @@ func TestSearchFieldClausesDiagnosticsNonNil(t *testing.T) {
 	if d.LogicalQueryType == "" || d.ExecutionStrategy == "" {
 		t.Fatalf("expected non-empty diagnostics labels, got %+v", *d)
 	}
-	if d.Timings["preprocess"] <= 0 {
+	if d.Timings.Preprocess <= 0 {
 		t.Fatalf("expected preprocess timing > 0, got %+v", d.Timings)
 	}
 }

--- a/pkg/fts/diagnostics_test.go
+++ b/pkg/fts/diagnostics_test.go
@@ -1,0 +1,295 @@
+package fts
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func requireDiagnostics(t *testing.T, res *SearchResult) *QueryDiagnostics {
+	t.Helper()
+	if res == nil {
+		t.Fatal("expected non-nil SearchResult")
+	}
+	if res.Diagnostics == nil {
+		t.Fatal("expected non-nil Diagnostics")
+	}
+	if res.Diagnostics.Timings["total"] <= 0 {
+		t.Fatalf("expected Diagnostics.Timings[total] > 0, got %v", res.Diagnostics.Timings["total"])
+	}
+	return res.Diagnostics
+}
+
+func TestSearchDiagnosticsTermStrategy(t *testing.T) {
+	svc := buildExecService(t)
+
+	res, err := svc.Search(context.Background(), TermQuery{Term: "barack"}, 10)
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	d := requireDiagnostics(t, res)
+	if d.LogicalQueryType != "term" {
+		t.Fatalf("LogicalQueryType = %q, want term", d.LogicalQueryType)
+	}
+	if d.ExecutionStrategy != "term" {
+		t.Fatalf("ExecutionStrategy = %q, want term", d.ExecutionStrategy)
+	}
+	if d.ReturnedDocs != len(res.Results) {
+		t.Fatalf("ReturnedDocs = %d, want %d", d.ReturnedDocs, len(res.Results))
+	}
+	if d.MatchedDocs != res.TotalResultsCount {
+		t.Fatalf("MatchedDocs = %d, want %d", d.MatchedDocs, res.TotalResultsCount)
+	}
+	if d.ProcessedTokens <= 0 || d.IndexSearches <= 0 || d.PostingEntriesRead <= 0 {
+		t.Fatalf("expected positive token/lookups/postings metrics, got %+v", *d)
+	}
+	if d.Timings["search_tokens"] <= 0 || d.Timings["total"] < d.Timings["search_tokens"] {
+		t.Fatalf("unexpected timings: %+v", d.Timings)
+	}
+	if d.Timings["total"] > 10*time.Second {
+		t.Fatalf("unexpectedly large timing: %+v", d.Timings)
+	}
+}
+
+func TestSearchDiagnosticsPrefixStrategy(t *testing.T) {
+	svc := buildExecService(t)
+
+	res, err := svc.Search(context.Background(), PrefixQuery{Field: "title", Prefix: "ba"}, 10)
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	d := requireDiagnostics(t, res)
+	if d.LogicalQueryType != "prefix" {
+		t.Fatalf("LogicalQueryType = %q, want prefix", d.LogicalQueryType)
+	}
+	if d.ExecutionStrategy != "prefix" {
+		t.Fatalf("ExecutionStrategy = %q, want prefix", d.ExecutionStrategy)
+	}
+	if d.FieldsVisited <= 0 || d.IndexSearches <= 0 || d.PostingEntriesRead <= 0 {
+		t.Fatalf("expected positive fields/lookups/postings metrics, got %+v", *d)
+	}
+}
+
+func TestSearchDiagnosticsBooleanOrWandStrategy(t *testing.T) {
+	idx := newMemoryIndex()
+	idx.entries["alpha"] = []DocRef{{ID: "doc-a", Count: 2, Seq: 1}, {ID: "doc-b", Count: 1, Seq: 2}, {ID: "doc-c", Count: 1, Seq: 3}, {ID: "doc-e", Count: 1, Seq: 5}}
+	idx.entries["beta"] = []DocRef{{ID: "doc-a", Count: 1, Seq: 1}, {ID: "doc-c", Count: 2, Seq: 3}, {ID: "doc-d", Count: 1, Seq: 4}}
+	idx.entries["gamma"] = []DocRef{{ID: "doc-c", Count: 1, Seq: 3}, {ID: "doc-d", Count: 3, Seq: 4}, {ID: "doc-e", Count: 1, Seq: 5}}
+
+	svc := New(idx, WordKeys, WithScorer(TFIDF()))
+	observeDefaultFieldLengths(svc, map[DocID]uint32{
+		"doc-a": 3,
+		"doc-b": 1,
+		"doc-c": 4,
+		"doc-d": 4,
+		"doc-e": 2,
+	})
+
+	q := &BooleanQuery{Clauses: []BoolClause{
+		ShouldClause(TermQuery{Term: "alpha"}),
+		ShouldClause(TermQuery{Term: "beta"}),
+		ShouldClause(TermQuery{Term: "gamma"}),
+	}}
+
+	res, err := svc.Search(context.Background(), q, 2)
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	d := requireDiagnostics(t, res)
+	if d.LogicalQueryType != "boolean" {
+		t.Fatalf("LogicalQueryType = %q, want boolean", d.LogicalQueryType)
+	}
+	if d.ExecutionStrategy != "bool_or_wand" {
+		t.Fatalf("ExecutionStrategy = %q, want bool_or_wand", d.ExecutionStrategy)
+	}
+	if d.ReturnedDocs != 2 {
+		t.Fatalf("ReturnedDocs = %d, want 2", d.ReturnedDocs)
+	}
+}
+
+func TestSearchDiagnosticsPhraseStrategy(t *testing.T) {
+	svc := buildExecService(t)
+
+	res, err := svc.Search(context.Background(), PhraseQuery{Phrase: "barack obama"}, 10)
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	d := requireDiagnostics(t, res)
+	if d.LogicalQueryType != "phrase" {
+		t.Fatalf("LogicalQueryType = %q, want phrase", d.LogicalQueryType)
+	}
+	if d.ExecutionStrategy != "phrase_exact" {
+		t.Fatalf("ExecutionStrategy = %q, want phrase_exact", d.ExecutionStrategy)
+	}
+	if d.ProcessedTokens <= 0 || d.PostingEntriesRead <= 0 {
+		t.Fatalf("expected positive phrase diagnostics, got %+v", *d)
+	}
+}
+
+func TestSearchDiagnosticsBooleanFallbackStrategy(t *testing.T) {
+	svc := buildExecService(t)
+	svc.scorer = TFIDF()
+	q := &BooleanQuery{Clauses: []BoolClause{
+		ShouldClause(PhraseQuery{Phrase: "barack obama"}),
+		ShouldClause(TermQuery{Term: "banana"}),
+	}}
+
+	res, err := svc.Search(context.Background(), q, 10)
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	d := requireDiagnostics(t, res)
+	if d.LogicalQueryType != "boolean" {
+		t.Fatalf("LogicalQueryType = %q, want boolean", d.LogicalQueryType)
+	}
+	if d.ExecutionStrategy != "bool_fallback" {
+		t.Fatalf("ExecutionStrategy = %q, want bool_fallback", d.ExecutionStrategy)
+	}
+	if d.StrategyReason != "wand_not_or_terms_only" {
+		t.Fatalf("StrategyReason = %q, want wand_not_or_terms_only", d.StrategyReason)
+	}
+}
+
+func TestSearchDiagnosticsBooleanAndFastStrategy(t *testing.T) {
+	svc := buildExecService(t)
+	q := &BooleanQuery{Clauses: []BoolClause{
+		MustClause(TermQuery{Field: "body", Term: "barack"}),
+		MustClause(TermQuery{Field: "body", Term: "mars"}),
+	}}
+
+	res, err := svc.Search(context.Background(), q, 10)
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	d := requireDiagnostics(t, res)
+	if d.LogicalQueryType != "boolean" {
+		t.Fatalf("LogicalQueryType = %q, want boolean", d.LogicalQueryType)
+	}
+	if d.ExecutionStrategy != "bool_and_fast_sort_merge" {
+		t.Fatalf("ExecutionStrategy = %q, want bool_and_fast_sort_merge", d.ExecutionStrategy)
+	}
+}
+
+func TestSearchDiagnosticsWandSkipReasonWithoutScorer(t *testing.T) {
+	idx := newMemoryIndex()
+	idx.entries["alpha"] = []DocRef{{ID: "doc-a", Count: 1, Seq: 1}}
+	idx.entries["beta"] = []DocRef{{ID: "doc-b", Count: 1, Seq: 2}}
+
+	svc := New(idx, WordKeys)
+	q := &BooleanQuery{Clauses: []BoolClause{
+		ShouldClause(TermQuery{Term: "alpha"}),
+		ShouldClause(TermQuery{Term: "beta"}),
+	}}
+
+	res, err := svc.Search(context.Background(), q, 1)
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	d := requireDiagnostics(t, res)
+	if d.LogicalQueryType != "boolean" {
+		t.Fatalf("LogicalQueryType = %q, want boolean", d.LogicalQueryType)
+	}
+	if d.ExecutionStrategy != "bool_or_fast" {
+		t.Fatalf("ExecutionStrategy = %q, want bool_or_fast", d.ExecutionStrategy)
+	}
+	if d.StrategyReason != "wand_disabled_no_scorer" {
+		t.Fatalf("StrategyReason = %q, want wand_disabled_no_scorer", d.StrategyReason)
+	}
+}
+
+func TestSearchDocumentsDiagnosticsNonNil(t *testing.T) {
+	svc := buildExecService(t)
+
+	res, err := svc.SearchDocuments(context.Background(), "barack", 10)
+	if err != nil {
+		t.Fatalf("SearchDocuments() error = %v", err)
+	}
+	d := requireDiagnostics(t, res)
+	if d.LogicalQueryType != "term" {
+		t.Fatalf("LogicalQueryType = %q, want term", d.LogicalQueryType)
+	}
+	if d.Timings["preprocess"] <= 0 {
+		t.Fatalf("expected preprocess timing > 0, got %+v", d.Timings)
+	}
+}
+
+func TestSearchFieldClausesDiagnosticsNonNil(t *testing.T) {
+	svc := buildExecService(t)
+
+	res, err := svc.SearchFieldClauses(context.Background(), []FieldQueryClause{
+		MustFieldQuery("title", "barack"),
+		MustNotFieldQuery("body", "russia"),
+	}, 10)
+	if err != nil {
+		t.Fatalf("SearchFieldClauses() error = %v", err)
+	}
+	d := requireDiagnostics(t, res)
+	if d.LogicalQueryType == "" || d.ExecutionStrategy == "" {
+		t.Fatalf("expected non-empty diagnostics labels, got %+v", *d)
+	}
+	if d.Timings["preprocess"] <= 0 {
+		t.Fatalf("expected preprocess timing > 0, got %+v", d.Timings)
+	}
+}
+
+func TestSearchPhrasePublicMethodsDiagnosticsNonNil(t *testing.T) {
+	svc := buildExecService(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		run  func() (*SearchResult, error)
+	}{
+		{name: "SearchPhrase", run: func() (*SearchResult, error) {
+			return svc.SearchPhrase(ctx, "barack obama", 10)
+		}},
+		{name: "SearchPhraseField", run: func() (*SearchResult, error) {
+			return svc.SearchPhraseField(ctx, "title", "barack obama", 10)
+		}},
+		{name: "SearchPhraseFields", run: func() (*SearchResult, error) {
+			return svc.SearchPhraseFields(ctx, []string{"title", "body"}, "barack obama", 10)
+		}},
+	}
+
+	for _, tc := range cases {
+		res, err := tc.run()
+		if err != nil {
+			t.Fatalf("%s() error = %v", tc.name, err)
+		}
+		d := requireDiagnostics(t, res)
+		if d.LogicalQueryType != "phrase" || d.ExecutionStrategy != "phrase_exact" {
+			t.Fatalf("%s diagnostics = %+v, want phrase/phrase_exact", tc.name, *d)
+		}
+	}
+}
+
+func TestSearchPhraseNearPublicMethodsDiagnosticsNonNil(t *testing.T) {
+	svc := buildExecService(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		run  func() (*SearchResult, error)
+	}{
+		{name: "SearchPhraseNear", run: func() (*SearchResult, error) {
+			return svc.SearchPhraseNear(ctx, "barack obama", 1, 10)
+		}},
+		{name: "SearchPhraseNearField", run: func() (*SearchResult, error) {
+			return svc.SearchPhraseNearField(ctx, "title", "barack obama", 1, 10)
+		}},
+		{name: "SearchPhraseNearFields", run: func() (*SearchResult, error) {
+			return svc.SearchPhraseNearFields(ctx, []string{"title", "body"}, "barack obama", 1, 10)
+		}},
+	}
+
+	for _, tc := range cases {
+		res, err := tc.run()
+		if err != nil {
+			t.Fatalf("%s() error = %v", tc.name, err)
+		}
+		d := requireDiagnostics(t, res)
+		if d.LogicalQueryType != "phrase_near" || d.ExecutionStrategy != "phrase_near" {
+			t.Fatalf("%s diagnostics = %+v, want phrase_near/phrase_near", tc.name, *d)
+		}
+	}
+}

--- a/pkg/fts/engine.go
+++ b/pkg/fts/engine.go
@@ -122,6 +122,7 @@ func (s *Service) searchQueryString(ctx context.Context, query string, defaultFi
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	ctx, exec := ensureDiagnosticsContext(ctx)
 
 	start := time.Now()
 	timings := make(map[string]string, 3)
@@ -132,16 +133,20 @@ func (s *Service) searchQueryString(ctx context.Context, query string, defaultFi
 		return nil, err
 	}
 	parsed = bindDefaultField(parsed, defaultField)
-	timings["preprocess"] = formatDuration(time.Since(preStart))
+	preprocess := time.Since(preStart)
+	timings["preprocess"] = formatDuration(preprocess)
+	exec.addTiming("preprocess", preprocess)
 
 	res, err := s.searchResultForQuery(ctx, parsed, maxResults, scope)
 	if err != nil {
 		return nil, err
 	}
 	timings["search_tokens"] = res.Timings["search_tokens"]
-	timings["total"] = formatDuration(time.Since(start))
+	total := time.Since(start)
+	timings["total"] = formatDuration(total)
+	exec.addTiming("total", total)
 	res.Timings = timings
-	return res, nil
+	return attachDiagnostics(ctx, res), nil
 }
 
 func (s *Service) SearchPhrase(ctx context.Context, phrase string, maxResults int) (*SearchResult, error) {

--- a/pkg/fts/engine.go
+++ b/pkg/fts/engine.go
@@ -125,7 +125,6 @@ func (s *Service) searchQueryString(ctx context.Context, query string, defaultFi
 	ctx, exec := ensureDiagnosticsContext(ctx)
 
 	start := time.Now()
-	timings := make(map[string]string, 3)
 
 	preStart := time.Now()
 	parsed, err := ParseQuery(query)
@@ -134,18 +133,14 @@ func (s *Service) searchQueryString(ctx context.Context, query string, defaultFi
 	}
 	parsed = bindDefaultField(parsed, defaultField)
 	preprocess := time.Since(preStart)
-	timings["preprocess"] = formatDuration(preprocess)
 	exec.addTiming("preprocess", preprocess)
 
 	res, err := s.searchResultForQuery(ctx, parsed, maxResults, scope)
 	if err != nil {
 		return nil, err
 	}
-	timings["search_tokens"] = res.Timings["search_tokens"]
 	total := time.Since(start)
-	timings["total"] = formatDuration(total)
 	exec.addTiming("total", total)
-	res.Timings = timings
 	return attachDiagnostics(ctx, res), nil
 }
 

--- a/pkg/fts/engine.go
+++ b/pkg/fts/engine.go
@@ -124,23 +124,21 @@ func (s *Service) searchQueryString(ctx context.Context, query string, defaultFi
 	}
 	ctx, exec := ensureDiagnosticsContext(ctx)
 
-	start := time.Now()
+	start := exec.startTimer()
 
-	preStart := time.Now()
+	preStart := exec.startTimer()
 	parsed, err := ParseQuery(query)
 	if err != nil {
 		return nil, err
 	}
 	parsed = bindDefaultField(parsed, defaultField)
-	preprocess := time.Since(preStart)
-	exec.setPreprocessTiming(preprocess)
+	exec.observePreprocess(preStart)
 
 	res, err := s.searchResultForQuery(ctx, parsed, maxResults, scope)
 	if err != nil {
 		return nil, err
 	}
-	total := time.Since(start)
-	exec.setTotalTiming(total)
+	exec.observeTotal(start)
 	return attachDiagnostics(ctx, res), nil
 }
 

--- a/pkg/fts/engine.go
+++ b/pkg/fts/engine.go
@@ -133,14 +133,14 @@ func (s *Service) searchQueryString(ctx context.Context, query string, defaultFi
 	}
 	parsed = bindDefaultField(parsed, defaultField)
 	preprocess := time.Since(preStart)
-	exec.addTiming("preprocess", preprocess)
+	exec.setPreprocessTiming(preprocess)
 
 	res, err := s.searchResultForQuery(ctx, parsed, maxResults, scope)
 	if err != nil {
 		return nil, err
 	}
 	total := time.Since(start)
-	exec.addTiming("total", total)
+	exec.setTotalTiming(total)
 	return attachDiagnostics(ctx, res), nil
 }
 

--- a/pkg/fts/engine_test.go
+++ b/pkg/fts/engine_test.go
@@ -105,7 +105,7 @@ func TestSearchDocumentsTieBreakerByID(t *testing.T) {
 	}
 }
 
-func TestSearchDocumentsReturnsTimings(t *testing.T) {
+func TestSearchDocumentsReturnsDiagnosticsTimings(t *testing.T) {
 	idx := newMemoryIndex()
 	idx.entries["one"] = []DocRef{{ID: "x", Count: 1}}
 
@@ -115,13 +115,16 @@ func TestSearchDocumentsReturnsTimings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SearchDocuments() error = %v", err)
 	}
+	if res.Diagnostics == nil {
+		t.Fatal("expected non-nil diagnostics")
+	}
 
 	for _, key := range []string{"preprocess", "search_tokens", "total"} {
-		if _, ok := res.Timings[key]; !ok {
+		if _, ok := res.Diagnostics.Timings[key]; !ok {
 			t.Fatalf("timings key %q missing", key)
 		}
-		if res.Timings[key] == "" {
-			t.Fatalf("timings key %q is empty", key)
+		if res.Diagnostics.Timings[key] <= 0 {
+			t.Fatalf("timings key %q is not positive", key)
 		}
 	}
 }

--- a/pkg/fts/engine_test.go
+++ b/pkg/fts/engine_test.go
@@ -119,13 +119,14 @@ func TestSearchDocumentsReturnsDiagnosticsTimings(t *testing.T) {
 		t.Fatal("expected non-nil diagnostics")
 	}
 
-	for _, key := range []string{"preprocess", "search_tokens", "total"} {
-		if _, ok := res.Diagnostics.Timings[key]; !ok {
-			t.Fatalf("timings key %q missing", key)
-		}
-		if res.Diagnostics.Timings[key] <= 0 {
-			t.Fatalf("timings key %q is not positive", key)
-		}
+	if !res.Diagnostics.Timings.HasPreprocess() || res.Diagnostics.Timings.Preprocess <= 0 {
+		t.Fatalf("expected positive preprocess timing, got %+v", res.Diagnostics.Timings)
+	}
+	if !res.Diagnostics.Timings.HasSearchTokens() || res.Diagnostics.Timings.SearchTokens <= 0 {
+		t.Fatalf("expected positive search_tokens timing, got %+v", res.Diagnostics.Timings)
+	}
+	if !res.Diagnostics.Timings.HasTotal() || res.Diagnostics.Timings.Total <= 0 {
+		t.Fatalf("expected positive total timing, got %+v", res.Diagnostics.Timings)
 	}
 }
 

--- a/pkg/fts/engine_test.go
+++ b/pkg/fts/engine_test.go
@@ -105,13 +105,28 @@ func TestSearchDocumentsTieBreakerByID(t *testing.T) {
 	}
 }
 
-func TestSearchDocumentsReturnsDiagnosticsTimings(t *testing.T) {
+func TestSearchDocumentsDiagnosticsDisabledByDefault(t *testing.T) {
 	idx := newMemoryIndex()
 	idx.entries["one"] = []DocRef{{ID: "x", Count: 1}}
 
 	svc := New(idx, WordKeys)
 
 	res, err := svc.SearchDocuments(context.Background(), "one", 1)
+	if err != nil {
+		t.Fatalf("SearchDocuments() error = %v", err)
+	}
+	if res.Diagnostics != nil {
+		t.Fatalf("expected nil diagnostics by default, got %+v", res.Diagnostics)
+	}
+}
+
+func TestSearchDocumentsReturnsDiagnosticsTimings(t *testing.T) {
+	idx := newMemoryIndex()
+	idx.entries["one"] = []DocRef{{ID: "x", Count: 1}}
+
+	svc := New(idx, WordKeys)
+
+	res, err := svc.SearchDocuments(WithDiagnostics(context.Background()), "one", 1)
 	if err != nil {
 		t.Fatalf("SearchDocuments() error = %v", err)
 	}

--- a/pkg/fts/executor.go
+++ b/pkg/fts/executor.go
@@ -41,11 +41,10 @@ func (s *Service) searchResultForQuery(ctx context.Context, q Query, maxResults 
 		exec.setQueryTypeIfEmpty("empty")
 		exec.setStrategy("empty")
 		exec.addTiming("total", 0)
-		return &SearchResult{Results: []Result{}, Timings: map[string]string{}}, nil
+		return &SearchResult{Results: []Result{}}, nil
 	}
 
 	start := time.Now()
-	timings := make(map[string]string, 2)
 
 	searchStart := time.Now()
 	hits, err := s.executeQuery(ctx, q, maxResults, scope)
@@ -53,13 +52,11 @@ func (s *Service) searchResultForQuery(ctx context.Context, q Query, maxResults 
 		return nil, err
 	}
 	searchTokens := time.Since(searchStart)
-	timings["search_tokens"] = formatDuration(searchTokens)
 	exec.addTiming("search_tokens", searchTokens)
 
 	total := time.Since(start)
-	timings["total"] = formatDuration(total)
 	exec.addTiming("total", total)
-	return searchResultFromHits(hits, maxResults, timings, s.scorer != nil), nil
+	return searchResultFromHits(hits, maxResults, s.scorer != nil), nil
 }
 
 func (s *Service) executeQuery(ctx context.Context, q Query, candidateLimit int, scope queryFieldScope) (map[DocID]docAccum, error) {

--- a/pkg/fts/executor.go
+++ b/pkg/fts/executor.go
@@ -15,18 +15,32 @@ func addAccum(a, b docAccum) docAccum {
 }
 
 func (s *Service) Search(ctx context.Context, q Query, maxResults int) (*SearchResult, error) {
-	return s.searchResultForQuery(ctx, q, maxResults, queryFieldScope{})
+	ctx, _ = ensureDiagnosticsContext(ctx)
+	res, err := s.searchResultForQuery(ctx, q, maxResults, queryFieldScope{})
+	if err != nil {
+		return nil, err
+	}
+	return attachDiagnostics(ctx, res), nil
 }
 
 func (s *Service) SearchQueryFields(ctx context.Context, fields []string, q Query, maxResults int) (*SearchResult, error) {
-	return s.searchResultForQuery(ctx, q, maxResults, newQueryFieldScope(fields))
+	ctx, _ = ensureDiagnosticsContext(ctx)
+	res, err := s.searchResultForQuery(ctx, q, maxResults, newQueryFieldScope(fields))
+	if err != nil {
+		return nil, err
+	}
+	return attachDiagnostics(ctx, res), nil
 }
 
 func (s *Service) searchResultForQuery(ctx context.Context, q Query, maxResults int, scope queryFieldScope) (*SearchResult, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	ctx, exec := ensureDiagnosticsContext(ctx)
 	if q == nil {
+		exec.setQueryTypeIfEmpty("empty")
+		exec.setStrategy("empty")
+		exec.addTiming("total", 0)
 		return &SearchResult{Results: []Result{}, Timings: map[string]string{}}, nil
 	}
 
@@ -38,13 +52,20 @@ func (s *Service) searchResultForQuery(ctx context.Context, q Query, maxResults 
 	if err != nil {
 		return nil, err
 	}
-	timings["search_tokens"] = formatDuration(time.Since(searchStart))
+	searchTokens := time.Since(searchStart)
+	timings["search_tokens"] = formatDuration(searchTokens)
+	exec.addTiming("search_tokens", searchTokens)
 
-	timings["total"] = formatDuration(time.Since(start))
+	total := time.Since(start)
+	timings["total"] = formatDuration(total)
+	exec.addTiming("total", total)
 	return searchResultFromHits(hits, maxResults, timings, s.scorer != nil), nil
 }
 
 func (s *Service) executeQuery(ctx context.Context, q Query, candidateLimit int, scope queryFieldScope) (map[DocID]docAccum, error) {
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.setQueryTypeIfEmpty(queryTypeOf(q))
+	}
 	switch t := q.(type) {
 	case TermQuery:
 		return s.execTerm(ctx, t, scope)

--- a/pkg/fts/executor.go
+++ b/pkg/fts/executor.go
@@ -40,7 +40,7 @@ func (s *Service) searchResultForQuery(ctx context.Context, q Query, maxResults 
 	if q == nil {
 		exec.setQueryTypeIfEmpty("empty")
 		exec.setStrategy("empty")
-		exec.addTiming("total", 0)
+		exec.setTotalTiming(0)
 		return &SearchResult{Results: []Result{}}, nil
 	}
 
@@ -52,10 +52,10 @@ func (s *Service) searchResultForQuery(ctx context.Context, q Query, maxResults 
 		return nil, err
 	}
 	searchTokens := time.Since(searchStart)
-	exec.addTiming("search_tokens", searchTokens)
+	exec.setSearchTokensTiming(searchTokens)
 
 	total := time.Since(start)
-	exec.addTiming("total", total)
+	exec.setTotalTiming(total)
 	return searchResultFromHits(hits, maxResults, s.scorer != nil), nil
 }
 

--- a/pkg/fts/executor.go
+++ b/pkg/fts/executor.go
@@ -38,7 +38,7 @@ func (s *Service) searchResultForQuery(ctx context.Context, q Query, maxResults 
 	ctx, exec := ensureDiagnosticsContext(ctx)
 	if q == nil {
 		exec.setQueryTypeIfEmpty("empty")
-		exec.setStrategy("empty")
+		exec.setStrategy(strategyEmpty)
 		exec.setTotalTiming(0)
 		return &SearchResult{Results: []Result{}}, nil
 	}

--- a/pkg/fts/executor.go
+++ b/pkg/fts/executor.go
@@ -3,7 +3,6 @@ package fts
 import (
 	"context"
 	"fmt"
-	"time"
 )
 
 func addAccum(a, b docAccum) docAccum {
@@ -44,18 +43,16 @@ func (s *Service) searchResultForQuery(ctx context.Context, q Query, maxResults 
 		return &SearchResult{Results: []Result{}}, nil
 	}
 
-	start := time.Now()
+	start := exec.startTimer()
 
-	searchStart := time.Now()
+	searchStart := exec.startTimer()
 	hits, err := s.executeQuery(ctx, q, maxResults, scope)
 	if err != nil {
 		return nil, err
 	}
-	searchTokens := time.Since(searchStart)
-	exec.setSearchTokensTiming(searchTokens)
+	exec.observeSearchTokens(searchStart)
+	exec.observeTotal(start)
 
-	total := time.Since(start)
-	exec.setTotalTiming(total)
 	return searchResultFromHits(hits, maxResults, s.scorer != nil), nil
 }
 

--- a/pkg/fts/field_positional.go
+++ b/pkg/fts/field_positional.go
@@ -149,16 +149,32 @@ func (s *Service) collectPositionalPostingsForToken(ctx context.Context, positio
 	if err != nil {
 		return nil, fmt.Errorf("fts: positional search: keygen: %w", err)
 	}
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.addKeys(len(keys))
+		exec.addTokens(1)
+	}
 
 	var merged map[DocID][]uint32
 	if len(keys) == 1 {
-		if s.filter != nil && !s.filter.Contains([]byte(keys[0])) {
-			return nil, nil
+		if s.filter != nil {
+			miss := !s.filter.Contains([]byte(keys[0]))
+			if exec := diagnosticsFromContext(ctx); exec != nil {
+				exec.addFilterCheck(miss)
+			}
+			if miss {
+				return nil, nil
+			}
 		}
 
+		if exec := diagnosticsFromContext(ctx); exec != nil {
+			exec.addIndexLookups(1)
+		}
 		refs, err := positional.SearchPositional(keys[0])
 		if err != nil {
 			return nil, fmt.Errorf("fts: positional search: index search: %w", err)
+		}
+		if exec := diagnosticsFromContext(ctx); exec != nil {
+			exec.addPostingsRead(len(refs))
 		}
 		merged = make(map[DocID][]uint32, len(refs))
 		for _, r := range refs {
@@ -171,13 +187,25 @@ func (s *Service) collectPositionalPostingsForToken(ctx context.Context, positio
 
 	merged = make(map[DocID][]uint32)
 	for _, key := range keys {
-		if s.filter != nil && !s.filter.Contains([]byte(key)) {
-			continue
+		if s.filter != nil {
+			miss := !s.filter.Contains([]byte(key))
+			if exec := diagnosticsFromContext(ctx); exec != nil {
+				exec.addFilterCheck(miss)
+			}
+			if miss {
+				continue
+			}
 		}
 
+		if exec := diagnosticsFromContext(ctx); exec != nil {
+			exec.addIndexLookups(1)
+		}
 		refs, err := positional.SearchPositional(key)
 		if err != nil {
 			return nil, fmt.Errorf("fts: positional search: index search: %w", err)
+		}
+		if exec := diagnosticsFromContext(ctx); exec != nil {
+			exec.addPostingsRead(len(refs))
 		}
 		for _, r := range refs {
 			if len(r.Positions) == 0 {

--- a/pkg/fts/field_positional.go
+++ b/pkg/fts/field_positional.go
@@ -145,37 +145,44 @@ func (s *Service) collectPositionalPostingsForToken(ctx context.Context, positio
 		return nil, err
 	}
 
+	exec := diagnosticsFromContext(ctx)
 	keys, err := s.keyGen(token)
 	if err != nil {
 		return nil, fmt.Errorf("fts: positional search: keygen: %w", err)
 	}
-	if exec := diagnosticsFromContext(ctx); exec != nil {
+	if exec != nil {
 		exec.addKeys(len(keys))
 		exec.addTokens(1)
 	}
+	var filterChecks, filterRejects, indexLookups, postingsRead int
+	defer func() {
+		if exec == nil {
+			return
+		}
+		exec.addFilterChecks(filterChecks, filterRejects)
+		exec.addIndexLookups(indexLookups)
+		exec.addPostingsRead(postingsRead)
+	}()
 
 	var merged map[DocID][]uint32
 	if len(keys) == 1 {
 		if s.filter != nil {
 			miss := !s.filter.Contains([]byte(keys[0]))
-			if exec := diagnosticsFromContext(ctx); exec != nil {
-				exec.addFilterCheck(miss)
+			filterChecks++
+			if miss {
+				filterRejects++
 			}
 			if miss {
 				return nil, nil
 			}
 		}
 
-		if exec := diagnosticsFromContext(ctx); exec != nil {
-			exec.addIndexLookups(1)
-		}
+		indexLookups++
 		refs, err := positional.SearchPositional(keys[0])
 		if err != nil {
 			return nil, fmt.Errorf("fts: positional search: index search: %w", err)
 		}
-		if exec := diagnosticsFromContext(ctx); exec != nil {
-			exec.addPostingsRead(len(refs))
-		}
+		postingsRead += len(refs)
 		merged = make(map[DocID][]uint32, len(refs))
 		for _, r := range refs {
 			if len(r.Positions) > 0 {
@@ -189,24 +196,21 @@ func (s *Service) collectPositionalPostingsForToken(ctx context.Context, positio
 	for _, key := range keys {
 		if s.filter != nil {
 			miss := !s.filter.Contains([]byte(key))
-			if exec := diagnosticsFromContext(ctx); exec != nil {
-				exec.addFilterCheck(miss)
+			filterChecks++
+			if miss {
+				filterRejects++
 			}
 			if miss {
 				continue
 			}
 		}
 
-		if exec := diagnosticsFromContext(ctx); exec != nil {
-			exec.addIndexLookups(1)
-		}
+		indexLookups++
 		refs, err := positional.SearchPositional(key)
 		if err != nil {
 			return nil, fmt.Errorf("fts: positional search: index search: %w", err)
 		}
-		if exec := diagnosticsFromContext(ctx); exec != nil {
-			exec.addPostingsRead(len(refs))
-		}
+		postingsRead += len(refs)
 		for _, r := range refs {
 			if len(r.Positions) == 0 {
 				continue

--- a/pkg/fts/field_prefix.go
+++ b/pkg/fts/field_prefix.go
@@ -76,9 +76,15 @@ func (s *Service) searchPrefixInField(ctx context.Context, field string, prefixe
 		return termExpansion{}, err
 	}
 
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.addIndexLookups(1)
+	}
 	docs, err := prefixer.SearchPrefix(prefix)
 	if err != nil {
 		return termExpansion{}, fmt.Errorf("fts: prefix query field %q: %w", field, err)
+	}
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.addPostingsRead(len(docs))
 	}
 	return termExpansion{
 		field:      field,

--- a/pkg/fts/field_prefix.go
+++ b/pkg/fts/field_prefix.go
@@ -76,16 +76,21 @@ func (s *Service) searchPrefixInField(ctx context.Context, field string, prefixe
 		return termExpansion{}, err
 	}
 
-	if exec := diagnosticsFromContext(ctx); exec != nil {
-		exec.addIndexLookups(1)
-	}
+	exec := diagnosticsFromContext(ctx)
+	var indexLookups, postingsRead int
+	defer func() {
+		if exec == nil {
+			return
+		}
+		exec.addIndexLookups(indexLookups)
+		exec.addPostingsRead(postingsRead)
+	}()
+	indexLookups++
 	docs, err := prefixer.SearchPrefix(prefix)
 	if err != nil {
 		return termExpansion{}, fmt.Errorf("fts: prefix query field %q: %w", field, err)
 	}
-	if exec := diagnosticsFromContext(ctx); exec != nil {
-		exec.addPostingsRead(len(docs))
-	}
+	postingsRead += len(docs)
 	return termExpansion{
 		field:      field,
 		term:       prefix + "*",

--- a/pkg/fts/field_query_clauses.go
+++ b/pkg/fts/field_query_clauses.go
@@ -36,7 +36,7 @@ func (s *Service) SearchFieldClauses(ctx context.Context, clauses []FieldQueryCl
 	ctx, exec := ensureDiagnosticsContext(ctx)
 	if len(clauses) == 0 {
 		exec.setQueryTypeIfEmpty("empty")
-		exec.setStrategy("empty")
+		exec.setStrategy(strategyEmpty)
 		return attachDiagnostics(ctx, &SearchResult{Results: []Result{}}), nil
 	}
 

--- a/pkg/fts/field_query_clauses.go
+++ b/pkg/fts/field_query_clauses.go
@@ -62,13 +62,13 @@ func (s *Service) SearchFieldClauses(ctx context.Context, clauses []FieldQueryCl
 		})
 	}
 	preprocess := time.Since(preStart)
-	exec.addTiming("preprocess", preprocess)
+	exec.setPreprocessTiming(preprocess)
 
 	res, err := s.searchResultForQuery(ctx, clausesToQuery(boolClauses), maxResults, queryFieldScope{})
 	if err != nil {
 		return nil, err
 	}
 	total := time.Since(start)
-	exec.addTiming("total", total)
+	exec.setTotalTiming(total)
 	return attachDiagnostics(ctx, res), nil
 }

--- a/pkg/fts/field_query_clauses.go
+++ b/pkg/fts/field_query_clauses.go
@@ -38,11 +38,10 @@ func (s *Service) SearchFieldClauses(ctx context.Context, clauses []FieldQueryCl
 	if len(clauses) == 0 {
 		exec.setQueryTypeIfEmpty("empty")
 		exec.setStrategy("empty")
-		return attachDiagnostics(ctx, &SearchResult{Results: []Result{}, Timings: map[string]string{}}), nil
+		return attachDiagnostics(ctx, &SearchResult{Results: []Result{}}), nil
 	}
 
 	start := time.Now()
-	timings := make(map[string]string, 3)
 
 	preStart := time.Now()
 
@@ -63,17 +62,13 @@ func (s *Service) SearchFieldClauses(ctx context.Context, clauses []FieldQueryCl
 		})
 	}
 	preprocess := time.Since(preStart)
-	timings["preprocess"] = formatDuration(preprocess)
 	exec.addTiming("preprocess", preprocess)
 
 	res, err := s.searchResultForQuery(ctx, clausesToQuery(boolClauses), maxResults, queryFieldScope{})
 	if err != nil {
 		return nil, err
 	}
-	timings["search_tokens"] = res.Timings["search_tokens"]
 	total := time.Since(start)
-	timings["total"] = formatDuration(total)
 	exec.addTiming("total", total)
-	res.Timings = timings
 	return attachDiagnostics(ctx, res), nil
 }

--- a/pkg/fts/field_query_clauses.go
+++ b/pkg/fts/field_query_clauses.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 )
 
 // FieldQueryClause binds a string subquery to a specific field and top-level boolean occur.
@@ -41,9 +40,9 @@ func (s *Service) SearchFieldClauses(ctx context.Context, clauses []FieldQueryCl
 		return attachDiagnostics(ctx, &SearchResult{Results: []Result{}}), nil
 	}
 
-	start := time.Now()
+	start := exec.startTimer()
 
-	preStart := time.Now()
+	preStart := exec.startTimer()
 
 	boolClauses := make([]BoolClause, 0, len(clauses))
 	for i, clause := range clauses {
@@ -61,14 +60,12 @@ func (s *Service) SearchFieldClauses(ctx context.Context, clauses []FieldQueryCl
 			Query: bindDefaultField(parsed, clause.Field),
 		})
 	}
-	preprocess := time.Since(preStart)
-	exec.setPreprocessTiming(preprocess)
+	exec.observePreprocess(preStart)
 
 	res, err := s.searchResultForQuery(ctx, clausesToQuery(boolClauses), maxResults, queryFieldScope{})
 	if err != nil {
 		return nil, err
 	}
-	total := time.Since(start)
-	exec.setTotalTiming(total)
+	exec.observeTotal(start)
 	return attachDiagnostics(ctx, res), nil
 }

--- a/pkg/fts/field_query_clauses.go
+++ b/pkg/fts/field_query_clauses.go
@@ -34,8 +34,11 @@ func (s *Service) SearchFieldClauses(ctx context.Context, clauses []FieldQueryCl
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	ctx, exec := ensureDiagnosticsContext(ctx)
 	if len(clauses) == 0 {
-		return &SearchResult{Results: []Result{}, Timings: map[string]string{}}, nil
+		exec.setQueryTypeIfEmpty("empty")
+		exec.setStrategy("empty")
+		return attachDiagnostics(ctx, &SearchResult{Results: []Result{}, Timings: map[string]string{}}), nil
 	}
 
 	start := time.Now()
@@ -59,14 +62,18 @@ func (s *Service) SearchFieldClauses(ctx context.Context, clauses []FieldQueryCl
 			Query: bindDefaultField(parsed, clause.Field),
 		})
 	}
-	timings["preprocess"] = formatDuration(time.Since(preStart))
+	preprocess := time.Since(preStart)
+	timings["preprocess"] = formatDuration(preprocess)
+	exec.addTiming("preprocess", preprocess)
 
 	res, err := s.searchResultForQuery(ctx, clausesToQuery(boolClauses), maxResults, queryFieldScope{})
 	if err != nil {
 		return nil, err
 	}
 	timings["search_tokens"] = res.Timings["search_tokens"]
-	timings["total"] = formatDuration(time.Since(start))
+	total := time.Since(start)
+	timings["total"] = formatDuration(total)
+	exec.addTiming("total", total)
 	res.Timings = timings
-	return res, nil
+	return attachDiagnostics(ctx, res), nil
 }

--- a/pkg/fts/field_query_clauses.go
+++ b/pkg/fts/field_query_clauses.go
@@ -1,0 +1,72 @@
+package fts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// FieldQueryClause binds a string subquery to a specific field and top-level boolean occur.
+type FieldQueryClause struct {
+	Field string
+	Query string
+	Occur Occur
+}
+
+func MustFieldQuery(field, query string) FieldQueryClause {
+	return FieldQueryClause{Field: field, Query: query, Occur: Must}
+}
+
+func ShouldFieldQuery(field, query string) FieldQueryClause {
+	return FieldQueryClause{Field: field, Query: query, Occur: Should}
+}
+
+func MustNotFieldQuery(field, query string) FieldQueryClause {
+	return FieldQueryClause{Field: field, Query: query, Occur: MustNot}
+}
+
+// SearchFieldClauses executes different string subqueries against different fields.
+//
+// Each clause is parsed independently, bound to its field as the default field,
+// then combined into a top-level BooleanQuery using the clause's Occur.
+func (s *Service) SearchFieldClauses(ctx context.Context, clauses []FieldQueryClause, maxResults int) (*SearchResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if len(clauses) == 0 {
+		return &SearchResult{Results: []Result{}, Timings: map[string]string{}}, nil
+	}
+
+	start := time.Now()
+	timings := make(map[string]string, 3)
+
+	preStart := time.Now()
+
+	boolClauses := make([]BoolClause, 0, len(clauses))
+	for i, clause := range clauses {
+		if strings.TrimSpace(clause.Query) == "" {
+			return nil, fmt.Errorf("fts: field query clause %d: empty query", i)
+		}
+
+		parsed, err := ParseQuery(clause.Query)
+		if err != nil {
+			return nil, fmt.Errorf("fts: field query clause %d: parse query: %w", i, err)
+		}
+
+		boolClauses = append(boolClauses, BoolClause{
+			Occur: clause.Occur,
+			Query: bindDefaultField(parsed, clause.Field),
+		})
+	}
+	timings["preprocess"] = formatDuration(time.Since(preStart))
+
+	res, err := s.searchResultForQuery(ctx, clausesToQuery(boolClauses), maxResults, queryFieldScope{})
+	if err != nil {
+		return nil, err
+	}
+	timings["search_tokens"] = res.Timings["search_tokens"]
+	timings["total"] = formatDuration(time.Since(start))
+	res.Timings = timings
+	return res, nil
+}

--- a/pkg/fts/field_term.go
+++ b/pkg/fts/field_term.go
@@ -70,15 +70,22 @@ func (s *Service) searchKeysInField(ctx context.Context, field string, index Ind
 
 	res := termFieldDocsResult{expansions: make([]termExpansion, 0, len(keys))}
 	fieldStats := s.fieldStatsFor(field)
+	exec := diagnosticsFromContext(ctx)
 	for _, key := range keys {
-		if s.filter != nil && !s.filter.Contains([]byte(key)) {
-			continue
+		if s.filter != nil {
+			miss := !s.filter.Contains([]byte(key))
+			exec.addFilterCheck(miss)
+			if miss {
+				continue
+			}
 		}
 
+		exec.addIndexLookups(1)
 		docs, err := index.Search(key)
 		if err != nil {
 			return termFieldDocsResult{}, fmt.Errorf("fts: term query field %q: index search: %w", field, err)
 		}
+		exec.addPostingsRead(len(docs))
 		if len(docs) == 0 {
 			continue
 		}

--- a/pkg/fts/field_term.go
+++ b/pkg/fts/field_term.go
@@ -71,21 +71,33 @@ func (s *Service) searchKeysInField(ctx context.Context, field string, index Ind
 	res := termFieldDocsResult{expansions: make([]termExpansion, 0, len(keys))}
 	fieldStats := s.fieldStatsFor(field)
 	exec := diagnosticsFromContext(ctx)
+	var filterChecks, filterRejects, indexLookups, postingsRead int
+	defer func() {
+		if exec == nil {
+			return
+		}
+		exec.addFilterChecks(filterChecks, filterRejects)
+		exec.addIndexLookups(indexLookups)
+		exec.addPostingsRead(postingsRead)
+	}()
 	for _, key := range keys {
 		if s.filter != nil {
 			miss := !s.filter.Contains([]byte(key))
-			exec.addFilterCheck(miss)
+			filterChecks++
+			if miss {
+				filterRejects++
+			}
 			if miss {
 				continue
 			}
 		}
 
-		exec.addIndexLookups(1)
+		indexLookups++
 		docs, err := index.Search(key)
 		if err != nil {
 			return termFieldDocsResult{}, fmt.Errorf("fts: term query field %q: index search: %w", field, err)
 		}
-		exec.addPostingsRead(len(docs))
+		postingsRead += len(docs)
 		if len(docs) == 0 {
 			continue
 		}

--- a/pkg/fts/multifield.go
+++ b/pkg/fts/multifield.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"time"
 )
 
 func (s *Service) Index(ctx context.Context, doc Document) error {
@@ -142,19 +141,17 @@ func (s *Service) searchPhraseFieldsResult(ctx context.Context, fields []string,
 	ctx, exec := ensureDiagnosticsContext(ctx)
 	exec.setQueryTypeIfEmpty("phrase")
 
-	start := time.Now()
+	start := exec.startTimer()
 
-	preStart := time.Now()
+	preStart := exec.startTimer()
 	plan := s.preparePhrase(fields, phrase)
-	preprocess := time.Since(preStart)
-	exec.setPreprocessTiming(preprocess)
+	exec.observePreprocess(preStart)
 	exec.addFields(len(fields))
 	exec.addTokens(len(plan.tokens))
 
 	if len(plan.tokens) == 0 {
 		exec.setSearchTokensTiming(0)
-		total := time.Since(start)
-		exec.setTotalTiming(total)
+		exec.observeTotal(start)
 		return attachDiagnostics(ctx, &SearchResult{Results: []Result{}}), nil
 	}
 	if plan.fallback != nil {
@@ -162,23 +159,19 @@ func (s *Service) searchPhraseFieldsResult(ctx context.Context, fields []string,
 		if err != nil {
 			return nil, err
 		}
-		total := time.Since(start)
-		exec.setTotalTiming(total)
+		exec.observeTotal(start)
 		return attachDiagnostics(ctx, res), nil
 	}
 	exec.setStrategy("phrase_exact")
 
-	searchStart := time.Now()
+	searchStart := exec.startTimer()
 	hits, err := s.evalExactPhraseTokenHits(ctx, fields, plan.tokens)
 	if err != nil {
 		return nil, err
 	}
 
-	searchTokens := time.Since(searchStart)
-	exec.setSearchTokensTiming(searchTokens)
-
-	total := time.Since(start)
-	exec.setTotalTiming(total)
+	exec.observeSearchTokens(searchStart)
+	exec.observeTotal(start)
 	return attachDiagnostics(ctx, searchResultFromHits(hits, maxResults, s.scorer != nil)), nil
 }
 
@@ -192,19 +185,17 @@ func (s *Service) searchPhraseNearFieldsResult(ctx context.Context, fields []str
 		return nil, fmt.Errorf("fts: phrase near search: negative distance %d", distance)
 	}
 
-	start := time.Now()
+	start := exec.startTimer()
 
-	preStart := time.Now()
+	preStart := exec.startTimer()
 	plan := s.preparePhrase(fields, phrase)
-	preprocess := time.Since(preStart)
-	exec.setPreprocessTiming(preprocess)
+	exec.observePreprocess(preStart)
 	exec.addFields(len(fields))
 	exec.addTokens(len(plan.tokens))
 
 	if len(plan.tokens) == 0 {
 		exec.setSearchTokensTiming(0)
-		total := time.Since(start)
-		exec.setTotalTiming(total)
+		exec.observeTotal(start)
 		return attachDiagnostics(ctx, &SearchResult{Results: []Result{}}), nil
 	}
 	if plan.fallback != nil {
@@ -212,23 +203,19 @@ func (s *Service) searchPhraseNearFieldsResult(ctx context.Context, fields []str
 		if err != nil {
 			return nil, err
 		}
-		total := time.Since(start)
-		exec.setTotalTiming(total)
+		exec.observeTotal(start)
 		return attachDiagnostics(ctx, res), nil
 	}
 	exec.setStrategy("phrase_near")
 
-	searchStart := time.Now()
+	searchStart := exec.startTimer()
 	hits, err := s.evalNearPhraseTokenHits(ctx, fields, plan.tokens, uint32(distance))
 	if err != nil {
 		return nil, err
 	}
 
-	searchTokens := time.Since(searchStart)
-	exec.setSearchTokensTiming(searchTokens)
-
-	total := time.Since(start)
-	exec.setTotalTiming(total)
+	exec.observeSearchTokens(searchStart)
+	exec.observeTotal(start)
 	return attachDiagnostics(ctx, searchResultFromHits(hits, maxResults, s.scorer != nil)), nil
 }
 

--- a/pkg/fts/multifield.go
+++ b/pkg/fts/multifield.go
@@ -139,22 +139,41 @@ func (s *Service) searchPhraseFieldsResult(ctx context.Context, fields []string,
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	ctx, exec := ensureDiagnosticsContext(ctx)
+	exec.setQueryTypeIfEmpty("phrase")
 
 	start := time.Now()
 	timings := make(map[string]string, 3)
 
 	preStart := time.Now()
 	plan := s.preparePhrase(fields, phrase)
-	timings["preprocess"] = formatDuration(time.Since(preStart))
+	preprocess := time.Since(preStart)
+	timings["preprocess"] = formatDuration(preprocess)
+	exec.addTiming("preprocess", preprocess)
+	exec.addFields(len(fields))
+	exec.addTokens(len(plan.tokens))
 
 	if len(plan.tokens) == 0 {
 		timings["search_tokens"] = formatDuration(0)
-		timings["total"] = formatDuration(time.Since(start))
-		return &SearchResult{Results: []Result{}, Timings: timings}, nil
+		exec.addTiming("search_tokens", 0)
+		total := time.Since(start)
+		timings["total"] = formatDuration(total)
+		exec.addTiming("total", total)
+		return attachDiagnostics(ctx, &SearchResult{Results: []Result{}, Timings: timings}), nil
 	}
 	if plan.fallback != nil {
-		return s.searchResultForQuery(ctx, *plan.fallback, maxResults, newQueryFieldScope(fields))
+		res, err := s.searchResultForQuery(ctx, *plan.fallback, maxResults, newQueryFieldScope(fields))
+		if err != nil {
+			return nil, err
+		}
+		timings["search_tokens"] = res.Timings["search_tokens"]
+		total := time.Since(start)
+		timings["total"] = formatDuration(total)
+		exec.addTiming("total", total)
+		res.Timings = timings
+		return attachDiagnostics(ctx, res), nil
 	}
+	exec.setStrategy("phrase_exact")
 
 	searchStart := time.Now()
 	hits, err := s.evalExactPhraseTokenHits(ctx, fields, plan.tokens)
@@ -162,16 +181,22 @@ func (s *Service) searchPhraseFieldsResult(ctx context.Context, fields []string,
 		return nil, err
 	}
 
-	timings["search_tokens"] = formatDuration(time.Since(searchStart))
+	searchTokens := time.Since(searchStart)
+	timings["search_tokens"] = formatDuration(searchTokens)
+	exec.addTiming("search_tokens", searchTokens)
 
-	timings["total"] = formatDuration(time.Since(start))
-	return searchResultFromHits(hits, maxResults, timings, s.scorer != nil), nil
+	total := time.Since(start)
+	timings["total"] = formatDuration(total)
+	exec.addTiming("total", total)
+	return attachDiagnostics(ctx, searchResultFromHits(hits, maxResults, timings, s.scorer != nil)), nil
 }
 
 func (s *Service) searchPhraseNearFieldsResult(ctx context.Context, fields []string, phrase string, distance int, maxResults int) (*SearchResult, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	ctx, exec := ensureDiagnosticsContext(ctx)
+	exec.setQueryTypeIfEmpty("phrase_near")
 	if distance < 0 {
 		return nil, fmt.Errorf("fts: phrase near search: negative distance %d", distance)
 	}
@@ -181,16 +206,33 @@ func (s *Service) searchPhraseNearFieldsResult(ctx context.Context, fields []str
 
 	preStart := time.Now()
 	plan := s.preparePhrase(fields, phrase)
-	timings["preprocess"] = formatDuration(time.Since(preStart))
+	preprocess := time.Since(preStart)
+	timings["preprocess"] = formatDuration(preprocess)
+	exec.addTiming("preprocess", preprocess)
+	exec.addFields(len(fields))
+	exec.addTokens(len(plan.tokens))
 
 	if len(plan.tokens) == 0 {
 		timings["search_tokens"] = formatDuration(0)
-		timings["total"] = formatDuration(time.Since(start))
-		return &SearchResult{Results: []Result{}, Timings: timings}, nil
+		exec.addTiming("search_tokens", 0)
+		total := time.Since(start)
+		timings["total"] = formatDuration(total)
+		exec.addTiming("total", total)
+		return attachDiagnostics(ctx, &SearchResult{Results: []Result{}, Timings: timings}), nil
 	}
 	if plan.fallback != nil {
-		return s.searchResultForQuery(ctx, *plan.fallback, maxResults, newQueryFieldScope(fields))
+		res, err := s.searchResultForQuery(ctx, *plan.fallback, maxResults, newQueryFieldScope(fields))
+		if err != nil {
+			return nil, err
+		}
+		timings["search_tokens"] = res.Timings["search_tokens"]
+		total := time.Since(start)
+		timings["total"] = formatDuration(total)
+		exec.addTiming("total", total)
+		res.Timings = timings
+		return attachDiagnostics(ctx, res), nil
 	}
+	exec.setStrategy("phrase_near")
 
 	searchStart := time.Now()
 	hits, err := s.evalNearPhraseTokenHits(ctx, fields, plan.tokens, uint32(distance))
@@ -198,10 +240,14 @@ func (s *Service) searchPhraseNearFieldsResult(ctx context.Context, fields []str
 		return nil, err
 	}
 
-	timings["search_tokens"] = formatDuration(time.Since(searchStart))
+	searchTokens := time.Since(searchStart)
+	timings["search_tokens"] = formatDuration(searchTokens)
+	exec.addTiming("search_tokens", searchTokens)
 
-	timings["total"] = formatDuration(time.Since(start))
-	return searchResultFromHits(hits, maxResults, timings, s.scorer != nil), nil
+	total := time.Since(start)
+	timings["total"] = formatDuration(total)
+	exec.addTiming("total", total)
+	return attachDiagnostics(ctx, searchResultFromHits(hits, maxResults, timings, s.scorer != nil)), nil
 }
 
 func (s *Service) SnapshotFields() (map[string]Index, Filter) {

--- a/pkg/fts/multifield.go
+++ b/pkg/fts/multifield.go
@@ -162,7 +162,7 @@ func (s *Service) searchPhraseFieldsResult(ctx context.Context, fields []string,
 		exec.observeTotal(start)
 		return attachDiagnostics(ctx, res), nil
 	}
-	exec.setStrategy("phrase_exact")
+	exec.setStrategy(strategyPhraseExact)
 
 	searchStart := exec.startTimer()
 	hits, err := s.evalExactPhraseTokenHits(ctx, fields, plan.tokens)
@@ -206,7 +206,7 @@ func (s *Service) searchPhraseNearFieldsResult(ctx context.Context, fields []str
 		exec.observeTotal(start)
 		return attachDiagnostics(ctx, res), nil
 	}
-	exec.setStrategy("phrase_near")
+	exec.setStrategy(strategyPhraseNear)
 
 	searchStart := exec.startTimer()
 	hits, err := s.evalNearPhraseTokenHits(ctx, fields, plan.tokens, uint32(distance))

--- a/pkg/fts/multifield.go
+++ b/pkg/fts/multifield.go
@@ -143,34 +143,27 @@ func (s *Service) searchPhraseFieldsResult(ctx context.Context, fields []string,
 	exec.setQueryTypeIfEmpty("phrase")
 
 	start := time.Now()
-	timings := make(map[string]string, 3)
 
 	preStart := time.Now()
 	plan := s.preparePhrase(fields, phrase)
 	preprocess := time.Since(preStart)
-	timings["preprocess"] = formatDuration(preprocess)
 	exec.addTiming("preprocess", preprocess)
 	exec.addFields(len(fields))
 	exec.addTokens(len(plan.tokens))
 
 	if len(plan.tokens) == 0 {
-		timings["search_tokens"] = formatDuration(0)
 		exec.addTiming("search_tokens", 0)
 		total := time.Since(start)
-		timings["total"] = formatDuration(total)
 		exec.addTiming("total", total)
-		return attachDiagnostics(ctx, &SearchResult{Results: []Result{}, Timings: timings}), nil
+		return attachDiagnostics(ctx, &SearchResult{Results: []Result{}}), nil
 	}
 	if plan.fallback != nil {
 		res, err := s.searchResultForQuery(ctx, *plan.fallback, maxResults, newQueryFieldScope(fields))
 		if err != nil {
 			return nil, err
 		}
-		timings["search_tokens"] = res.Timings["search_tokens"]
 		total := time.Since(start)
-		timings["total"] = formatDuration(total)
 		exec.addTiming("total", total)
-		res.Timings = timings
 		return attachDiagnostics(ctx, res), nil
 	}
 	exec.setStrategy("phrase_exact")
@@ -182,13 +175,11 @@ func (s *Service) searchPhraseFieldsResult(ctx context.Context, fields []string,
 	}
 
 	searchTokens := time.Since(searchStart)
-	timings["search_tokens"] = formatDuration(searchTokens)
 	exec.addTiming("search_tokens", searchTokens)
 
 	total := time.Since(start)
-	timings["total"] = formatDuration(total)
 	exec.addTiming("total", total)
-	return attachDiagnostics(ctx, searchResultFromHits(hits, maxResults, timings, s.scorer != nil)), nil
+	return attachDiagnostics(ctx, searchResultFromHits(hits, maxResults, s.scorer != nil)), nil
 }
 
 func (s *Service) searchPhraseNearFieldsResult(ctx context.Context, fields []string, phrase string, distance int, maxResults int) (*SearchResult, error) {
@@ -202,34 +193,27 @@ func (s *Service) searchPhraseNearFieldsResult(ctx context.Context, fields []str
 	}
 
 	start := time.Now()
-	timings := make(map[string]string, 3)
 
 	preStart := time.Now()
 	plan := s.preparePhrase(fields, phrase)
 	preprocess := time.Since(preStart)
-	timings["preprocess"] = formatDuration(preprocess)
 	exec.addTiming("preprocess", preprocess)
 	exec.addFields(len(fields))
 	exec.addTokens(len(plan.tokens))
 
 	if len(plan.tokens) == 0 {
-		timings["search_tokens"] = formatDuration(0)
 		exec.addTiming("search_tokens", 0)
 		total := time.Since(start)
-		timings["total"] = formatDuration(total)
 		exec.addTiming("total", total)
-		return attachDiagnostics(ctx, &SearchResult{Results: []Result{}, Timings: timings}), nil
+		return attachDiagnostics(ctx, &SearchResult{Results: []Result{}}), nil
 	}
 	if plan.fallback != nil {
 		res, err := s.searchResultForQuery(ctx, *plan.fallback, maxResults, newQueryFieldScope(fields))
 		if err != nil {
 			return nil, err
 		}
-		timings["search_tokens"] = res.Timings["search_tokens"]
 		total := time.Since(start)
-		timings["total"] = formatDuration(total)
 		exec.addTiming("total", total)
-		res.Timings = timings
 		return attachDiagnostics(ctx, res), nil
 	}
 	exec.setStrategy("phrase_near")
@@ -241,13 +225,11 @@ func (s *Service) searchPhraseNearFieldsResult(ctx context.Context, fields []str
 	}
 
 	searchTokens := time.Since(searchStart)
-	timings["search_tokens"] = formatDuration(searchTokens)
 	exec.addTiming("search_tokens", searchTokens)
 
 	total := time.Since(start)
-	timings["total"] = formatDuration(total)
 	exec.addTiming("total", total)
-	return attachDiagnostics(ctx, searchResultFromHits(hits, maxResults, timings, s.scorer != nil)), nil
+	return attachDiagnostics(ctx, searchResultFromHits(hits, maxResults, s.scorer != nil)), nil
 }
 
 func (s *Service) SnapshotFields() (map[string]Index, Filter) {

--- a/pkg/fts/multifield.go
+++ b/pkg/fts/multifield.go
@@ -147,14 +147,14 @@ func (s *Service) searchPhraseFieldsResult(ctx context.Context, fields []string,
 	preStart := time.Now()
 	plan := s.preparePhrase(fields, phrase)
 	preprocess := time.Since(preStart)
-	exec.addTiming("preprocess", preprocess)
+	exec.setPreprocessTiming(preprocess)
 	exec.addFields(len(fields))
 	exec.addTokens(len(plan.tokens))
 
 	if len(plan.tokens) == 0 {
-		exec.addTiming("search_tokens", 0)
+		exec.setSearchTokensTiming(0)
 		total := time.Since(start)
-		exec.addTiming("total", total)
+		exec.setTotalTiming(total)
 		return attachDiagnostics(ctx, &SearchResult{Results: []Result{}}), nil
 	}
 	if plan.fallback != nil {
@@ -163,7 +163,7 @@ func (s *Service) searchPhraseFieldsResult(ctx context.Context, fields []string,
 			return nil, err
 		}
 		total := time.Since(start)
-		exec.addTiming("total", total)
+		exec.setTotalTiming(total)
 		return attachDiagnostics(ctx, res), nil
 	}
 	exec.setStrategy("phrase_exact")
@@ -175,10 +175,10 @@ func (s *Service) searchPhraseFieldsResult(ctx context.Context, fields []string,
 	}
 
 	searchTokens := time.Since(searchStart)
-	exec.addTiming("search_tokens", searchTokens)
+	exec.setSearchTokensTiming(searchTokens)
 
 	total := time.Since(start)
-	exec.addTiming("total", total)
+	exec.setTotalTiming(total)
 	return attachDiagnostics(ctx, searchResultFromHits(hits, maxResults, s.scorer != nil)), nil
 }
 
@@ -197,14 +197,14 @@ func (s *Service) searchPhraseNearFieldsResult(ctx context.Context, fields []str
 	preStart := time.Now()
 	plan := s.preparePhrase(fields, phrase)
 	preprocess := time.Since(preStart)
-	exec.addTiming("preprocess", preprocess)
+	exec.setPreprocessTiming(preprocess)
 	exec.addFields(len(fields))
 	exec.addTokens(len(plan.tokens))
 
 	if len(plan.tokens) == 0 {
-		exec.addTiming("search_tokens", 0)
+		exec.setSearchTokensTiming(0)
 		total := time.Since(start)
-		exec.addTiming("total", total)
+		exec.setTotalTiming(total)
 		return attachDiagnostics(ctx, &SearchResult{Results: []Result{}}), nil
 	}
 	if plan.fallback != nil {
@@ -213,7 +213,7 @@ func (s *Service) searchPhraseNearFieldsResult(ctx context.Context, fields []str
 			return nil, err
 		}
 		total := time.Since(start)
-		exec.addTiming("total", total)
+		exec.setTotalTiming(total)
 		return attachDiagnostics(ctx, res), nil
 	}
 	exec.setStrategy("phrase_near")
@@ -225,10 +225,10 @@ func (s *Service) searchPhraseNearFieldsResult(ctx context.Context, fields []str
 	}
 
 	searchTokens := time.Since(searchStart)
-	exec.addTiming("search_tokens", searchTokens)
+	exec.setSearchTokensTiming(searchTokens)
 
 	total := time.Since(start)
-	exec.addTiming("total", total)
+	exec.setTotalTiming(total)
 	return attachDiagnostics(ctx, searchResultFromHits(hits, maxResults, s.scorer != nil)), nil
 }
 

--- a/pkg/fts/multifield_test.go
+++ b/pkg/fts/multifield_test.go
@@ -296,6 +296,60 @@ func TestSearchQueryFieldsRestrictsASTQueryToSubset(t *testing.T) {
 	}
 }
 
+func TestSearchFieldClausesCombinesDifferentQueriesAcrossFields(t *testing.T) {
+	title := newMemoryIndex()
+	title.entries["barack"] = []DocRef{{ID: "doc-1", Count: 1, Seq: 0}, {ID: "doc-2", Count: 1, Seq: 1}}
+	body := newMemoryIndex()
+	body.entries["obama"] = []DocRef{{ID: "doc-3", Count: 1, Seq: 0}, {ID: "doc-2", Count: 1, Seq: 1}}
+
+	svc := NewMultiFieldFromIndexes(map[string]Index{
+		"title": title,
+		"body":  body,
+	}, WordKeys)
+
+	res, err := svc.SearchFieldClauses(context.Background(), []FieldQueryClause{
+		MustFieldQuery("title", "barack"),
+		MustFieldQuery("body", "obama"),
+	}, 10)
+	if err != nil {
+		t.Fatalf("SearchFieldClauses() error = %v", err)
+	}
+	if res.TotalResultsCount != 1 || len(res.Results) != 1 || res.Results[0].ID != "doc-2" {
+		t.Fatalf("expected only doc-2 after field-specific MUST clauses, got %+v", res.Results)
+	}
+}
+
+func TestSearchFieldClausesSupportsFieldSpecificPhraseAndExclusion(t *testing.T) {
+	factory := func(name string) (Index, error) { return newPositionalMemoryIndex(), nil }
+	svc := NewMultiField(factory, WordKeys)
+
+	ctx := context.Background()
+	if err := svc.Index(ctx, Document{ID: "doc-a", Fields: map[string]Field{
+		"title": {Value: "barack"},
+		"body":  {Value: "french hotel"},
+	}}); err != nil {
+		t.Fatalf("Index() error = %v", err)
+	}
+	if err := svc.Index(ctx, Document{ID: "doc-b", Fields: map[string]Field{
+		"title": {Value: "barack"},
+		"body":  {Value: "market hotel"},
+	}}); err != nil {
+		t.Fatalf("Index() error = %v", err)
+	}
+
+	res, err := svc.SearchFieldClauses(ctx, []FieldQueryClause{
+		MustFieldQuery("title", "barack"),
+		MustFieldQuery("body", `"french hotel"`),
+		MustNotFieldQuery("body", "market"),
+	}, 10)
+	if err != nil {
+		t.Fatalf("SearchFieldClauses() error = %v", err)
+	}
+	if len(res.Results) != 1 || res.Results[0].ID != "doc-a" {
+		t.Fatalf("expected only doc-a after field-specific phrase and exclusion, got %+v", res.Results)
+	}
+}
+
 func TestSearchDocumentsMustAcrossFieldsIntersectsByDocID(t *testing.T) {
 	title := newMemoryIndex()
 	title.entries["barack"] = []DocRef{{ID: "doc-1", Count: 1, Seq: 0}, {ID: "doc-2", Count: 1, Seq: 1}}

--- a/pkg/fts/phrase_eval.go
+++ b/pkg/fts/phrase_eval.go
@@ -32,11 +32,18 @@ func (s *Service) preparePhrase(fields []string, phrase string) phrasePlan {
 
 func (s *Service) evalPhraseHits(ctx context.Context, fields []string, phrase string, scope queryFieldScope) (map[DocID]docAccum, error) {
 	plan := s.preparePhrase(fields, phrase)
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.addFields(len(fields))
+		exec.addTokens(len(plan.tokens))
+	}
 	if len(plan.tokens) == 0 {
 		return map[DocID]docAccum{}, nil
 	}
 	if plan.fallback != nil {
 		return s.executeQuery(ctx, *plan.fallback, 0, scope)
+	}
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.setStrategy("phrase_exact")
 	}
 	return s.evalExactPhraseTokenHits(ctx, fields, plan.tokens)
 }

--- a/pkg/fts/phrase_eval.go
+++ b/pkg/fts/phrase_eval.go
@@ -43,7 +43,7 @@ func (s *Service) evalPhraseHits(ctx context.Context, fields []string, phrase st
 		return s.executeQuery(ctx, *plan.fallback, 0, scope)
 	}
 	if exec := diagnosticsFromContext(ctx); exec != nil {
-		exec.setStrategy("phrase_exact")
+		exec.setStrategy(strategyPhraseExact)
 	}
 	return s.evalExactPhraseTokenHits(ctx, fields, plan.tokens)
 }

--- a/pkg/fts/prefix_eval.go
+++ b/pkg/fts/prefix_eval.go
@@ -4,7 +4,7 @@ import "context"
 
 func (s *Service) execPrefix(ctx context.Context, q PrefixQuery, scope queryFieldScope) (map[DocID]docAccum, error) {
 	if exec := diagnosticsFromContext(ctx); exec != nil {
-		exec.setStrategy("prefix")
+		exec.setStrategy(strategyPrefix)
 	}
 	if q.Prefix == "" {
 		return map[DocID]docAccum{}, nil

--- a/pkg/fts/prefix_eval.go
+++ b/pkg/fts/prefix_eval.go
@@ -3,6 +3,9 @@ package fts
 import "context"
 
 func (s *Service) execPrefix(ctx context.Context, q PrefixQuery, scope queryFieldScope) (map[DocID]docAccum, error) {
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.setStrategy("prefix")
+	}
 	if q.Prefix == "" {
 		return map[DocID]docAccum{}, nil
 	}
@@ -11,6 +14,9 @@ func (s *Service) execPrefix(ctx context.Context, q PrefixQuery, scope queryFiel
 	}
 
 	fields := s.resolveScopedFields(q.Field, scope)
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.addFields(len(fields))
+	}
 	expansions, err := s.collectPrefixFieldDocs(ctx, fields, q.Prefix)
 	if err != nil {
 		return nil, err

--- a/pkg/fts/search_result.go
+++ b/pkg/fts/search_result.go
@@ -2,7 +2,7 @@ package fts
 
 import "sort"
 
-func searchResultFromHits(hits map[DocID]docAccum, maxResults int, timings map[string]string, useScore bool) *SearchResult {
+func searchResultFromHits(hits map[DocID]docAccum, maxResults int, useScore bool) *SearchResult {
 	results, totalFound := resultsFromHits(hits, useScore)
 	if maxResults <= 0 || maxResults > totalFound {
 		maxResults = totalFound
@@ -10,7 +10,6 @@ func searchResultFromHits(hits map[DocID]docAccum, maxResults int, timings map[s
 	return &SearchResult{
 		Results:           results[:maxResults],
 		TotalResultsCount: totalFound,
-		Timings:           timings,
 	}
 }
 

--- a/pkg/fts/term_eval.go
+++ b/pkg/fts/term_eval.go
@@ -7,7 +7,7 @@ import (
 
 func (s *Service) execTerm(ctx context.Context, q TermQuery, scope queryFieldScope) (map[DocID]docAccum, error) {
 	if exec := diagnosticsFromContext(ctx); exec != nil {
-		exec.setStrategy("term")
+		exec.setStrategy(strategyTerm)
 	}
 	if q.Term == "" {
 		return map[DocID]docAccum{}, nil

--- a/pkg/fts/term_eval.go
+++ b/pkg/fts/term_eval.go
@@ -6,6 +6,9 @@ import (
 )
 
 func (s *Service) execTerm(ctx context.Context, q TermQuery, scope queryFieldScope) (map[DocID]docAccum, error) {
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.setStrategy("term")
+	}
 	if q.Term == "" {
 		return map[DocID]docAccum{}, nil
 	}
@@ -15,6 +18,10 @@ func (s *Service) execTerm(ctx context.Context, q TermQuery, scope queryFieldSco
 		return map[DocID]docAccum{}, nil
 	}
 	fields := s.resolveScopedFields(q.Field, scope)
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.addTokens(len(tokens))
+		exec.addFields(len(fields))
+	}
 	keyGroups := make([][]string, len(tokens))
 	for i, token := range tokens {
 		keys, err := s.keyGen(token)
@@ -22,6 +29,9 @@ func (s *Service) execTerm(ctx context.Context, q TermQuery, scope queryFieldSco
 			return nil, fmt.Errorf("fts: term query: keygen: %w", err)
 		}
 		keyGroups[i] = keys
+		if exec := diagnosticsFromContext(ctx); exec != nil {
+			exec.addKeys(len(keys))
+		}
 	}
 
 	plan := make([]tokenGroup, 0, len(tokens))

--- a/pkg/fts/types.go
+++ b/pkg/fts/types.go
@@ -101,6 +101,7 @@ type RetryableStaticFilter interface {
 
 type Engine interface {
 	IndexDocument(ctx context.Context, docID DocID, content string) error
+	Search(ctx context.Context, q Query, maxResults int) (*SearchResult, error)
 	SearchDocuments(ctx context.Context, query string, maxResults int) (*SearchResult, error)
 }
 

--- a/pkg/fts/types.go
+++ b/pkg/fts/types.go
@@ -24,6 +24,7 @@ type SearchResult struct {
 	Results           []Result
 	TotalResultsCount int
 	Timings           map[string]string
+	Diagnostics       *QueryDiagnostics
 }
 
 const DefaultField = "_default"

--- a/pkg/fts/types.go
+++ b/pkg/fts/types.go
@@ -23,7 +23,6 @@ type Result struct {
 type SearchResult struct {
 	Results           []Result
 	TotalResultsCount int
-	Timings           map[string]string
 	Diagnostics       *QueryDiagnostics
 }
 

--- a/pkg/fts/types.go
+++ b/pkg/fts/types.go
@@ -102,6 +102,7 @@ type RetryableStaticFilter interface {
 type Engine interface {
 	IndexDocument(ctx context.Context, docID DocID, content string) error
 	Search(ctx context.Context, q Query, maxResults int) (*SearchResult, error)
+	SearchFieldClauses(ctx context.Context, clauses []FieldQueryClause, maxResults int) (*SearchResult, error)
 	SearchDocuments(ctx context.Context, query string, maxResults int) (*SearchResult, error)
 }
 

--- a/pkg/fts/wand.go
+++ b/pkg/fts/wand.go
@@ -8,23 +8,44 @@ import (
 )
 
 func (s *Service) tryExecBooleanOrWand(ctx context.Context, q *BooleanQuery, candidateLimit int, scope queryFieldScope) (map[DocID]docAccum, bool, error) {
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
+			b.WAND.TopK = candidateLimit
+		})
+	}
 	if candidateLimit <= 0 || s.scorer == nil {
 		if exec := diagnosticsFromContext(ctx); exec != nil {
+			reason := "wand_disabled_no_topk"
 			if candidateLimit <= 0 {
-				exec.setReasonIfEmpty("wand_disabled_no_topk")
+				exec.setSkipReasonIfEmpty(reason)
 			} else {
-				exec.setReasonIfEmpty("wand_disabled_no_scorer")
+				reason = "wand_disabled_no_scorer"
+				exec.setSkipReasonIfEmpty(reason)
 			}
+			exec.recordFastPathSkip(reason)
+			exec.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
+				b.WAND.SkipReason = reason
+			})
 		}
 		return nil, false, nil
 	}
 
-	shouldTerms, mustNots, ok := parseFastOrClauses(q)
+	shouldTerms, mustNots, ok, _ := parseFastOrClauses(q)
 	if !ok || len(shouldTerms) == 0 {
 		if exec := diagnosticsFromContext(ctx); exec != nil {
-			exec.setReasonIfEmpty("wand_not_or_terms_only")
+			reason := "wand_not_or_terms_only"
+			exec.setSkipReasonIfEmpty(reason)
+			exec.recordFastPathSkip(reason)
+			exec.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
+				b.WAND.SkipReason = reason
+			})
 		}
 		return nil, false, nil
+	}
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
+			b.WAND.ClauseCount = len(shouldTerms)
+		})
 	}
 
 	exclude, err := s.buildExcludeSet(ctx, mustNots, scope)
@@ -33,6 +54,7 @@ func (s *Service) tryExecBooleanOrWand(ctx context.Context, q *BooleanQuery, can
 	}
 
 	plan := make([]fastMust, 0, len(shouldTerms))
+	postingsPerClause := make([]int, 0, len(shouldTerms))
 	for _, term := range shouldTerms {
 		if err := ctx.Err(); err != nil {
 			return nil, false, err
@@ -41,29 +63,50 @@ func (s *Service) tryExecBooleanOrWand(ctx context.Context, q *BooleanQuery, can
 		if err != nil {
 			return nil, false, err
 		}
+		postingsPerClause = append(postingsPerClause, group.totalDocs)
 		if group.totalDocs == 0 {
 			continue
 		}
 		plan = append(plan, group)
 	}
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
+			b.WAND.PostingsPerClause = append([]int(nil), postingsPerClause...)
+		})
+	}
 	if len(plan) == 0 {
 		if exec := diagnosticsFromContext(ctx); exec != nil {
 			exec.setStrategy("bool_or_wand")
+			exec.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
+				b.WAND.Eligible = true
+				b.WAND.Used = true
+				b.WAND.HeapSize = 0
+			})
 		}
 		return map[DocID]docAccum{}, true, nil
 	}
 	if !allSingleExpansionInSameField(plan) || !allClausesHaveStrictSeq(plan) {
 		if exec := diagnosticsFromContext(ctx); exec != nil {
+			reason := "wand_multiple_expansions_or_fields"
 			if !allSingleExpansionInSameField(plan) {
-				exec.setReasonIfEmpty("wand_multiple_expansions_or_fields")
+				exec.setSkipReasonIfEmpty(reason)
 			} else {
-				exec.setReasonIfEmpty("wand_non_strict_seq")
+				reason = "wand_non_strict_seq"
+				exec.setSkipReasonIfEmpty(reason)
 			}
+			exec.recordFastPathSkip(reason)
+			exec.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
+				b.WAND.SkipReason = reason
+			})
 		}
 		return nil, false, nil
 	}
 	if exec := diagnosticsFromContext(ctx); exec != nil {
 		exec.setStrategy("bool_or_wand")
+		exec.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
+			b.WAND.Eligible = true
+			b.WAND.Used = true
+		})
 	}
 
 	clauses := make([]*wandClause, 0, len(plan))
@@ -79,6 +122,8 @@ func (s *Service) tryExecBooleanOrWand(ctx context.Context, q *BooleanQuery, can
 	h := &candidateHeap{}
 	heap.Init(h)
 	var theta float64
+	postingsConsidered := 0
+	candidateDocs := 0
 
 	for {
 		if err := ctx.Err(); err != nil {
@@ -109,6 +154,7 @@ func (s *Service) tryExecBooleanOrWand(ctx context.Context, q *BooleanQuery, can
 
 		pivotSeq := clauses[pivot].currentSeq()
 		if clauses[0].currentSeq() == pivotSeq {
+			candidateDocs++
 			matchedDocID := clauses[0].currentDocID()
 			var accum docAccum
 			for _, c := range clauses {
@@ -137,6 +183,7 @@ func (s *Service) tryExecBooleanOrWand(ctx context.Context, q *BooleanQuery, can
 
 			for _, c := range clauses {
 				if c.currentSeq() == pivotSeq {
+					postingsConsidered++
 					c.cursor++
 				}
 			}
@@ -147,6 +194,7 @@ func (s *Service) tryExecBooleanOrWand(ctx context.Context, q *BooleanQuery, can
 			c := clauses[i]
 			if c.currentSeq() < pivotSeq {
 				for c.cursor < len(c.exp.docs) && c.exp.docs[c.cursor].Seq < pivotSeq {
+					postingsConsidered++
 					c.cursor++
 				}
 				break
@@ -157,6 +205,14 @@ func (s *Service) tryExecBooleanOrWand(ctx context.Context, q *BooleanQuery, can
 	out := make(map[DocID]docAccum, h.Len())
 	for _, hit := range *h {
 		out[hit.id] = hit.accum
+	}
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
+			b.WAND.PostingsConsidered = postingsConsidered
+			b.WAND.CandidateDocs = candidateDocs
+			b.WAND.HeapSize = h.Len()
+			b.WAND.FinalTheta = theta
+		})
 	}
 	return out, true, nil
 }

--- a/pkg/fts/wand.go
+++ b/pkg/fts/wand.go
@@ -76,7 +76,7 @@ func (s *Service) tryExecBooleanOrWand(ctx context.Context, q *BooleanQuery, can
 	}
 	if len(plan) == 0 {
 		if exec := diagnosticsFromContext(ctx); exec != nil {
-			exec.setStrategy("bool_or_wand")
+			exec.setStrategy(strategyBoolOrWAND)
 			exec.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
 				b.WAND.Eligible = true
 				b.WAND.Used = true
@@ -102,7 +102,7 @@ func (s *Service) tryExecBooleanOrWand(ctx context.Context, q *BooleanQuery, can
 		return nil, false, nil
 	}
 	if exec := diagnosticsFromContext(ctx); exec != nil {
-		exec.setStrategy("bool_or_wand")
+		exec.setStrategy(strategyBoolOrWAND)
 		exec.updateBooleanDiagnostics(func(b *BooleanDiagnostics) {
 			b.WAND.Eligible = true
 			b.WAND.Used = true

--- a/pkg/fts/wand.go
+++ b/pkg/fts/wand.go
@@ -9,11 +9,21 @@ import (
 
 func (s *Service) tryExecBooleanOrWand(ctx context.Context, q *BooleanQuery, candidateLimit int, scope queryFieldScope) (map[DocID]docAccum, bool, error) {
 	if candidateLimit <= 0 || s.scorer == nil {
+		if exec := diagnosticsFromContext(ctx); exec != nil {
+			if candidateLimit <= 0 {
+				exec.setReasonIfEmpty("wand_disabled_no_topk")
+			} else {
+				exec.setReasonIfEmpty("wand_disabled_no_scorer")
+			}
+		}
 		return nil, false, nil
 	}
 
 	shouldTerms, mustNots, ok := parseFastOrClauses(q)
 	if !ok || len(shouldTerms) == 0 {
+		if exec := diagnosticsFromContext(ctx); exec != nil {
+			exec.setReasonIfEmpty("wand_not_or_terms_only")
+		}
 		return nil, false, nil
 	}
 
@@ -37,10 +47,23 @@ func (s *Service) tryExecBooleanOrWand(ctx context.Context, q *BooleanQuery, can
 		plan = append(plan, group)
 	}
 	if len(plan) == 0 {
+		if exec := diagnosticsFromContext(ctx); exec != nil {
+			exec.setStrategy("bool_or_wand")
+		}
 		return map[DocID]docAccum{}, true, nil
 	}
 	if !allSingleExpansionInSameField(plan) || !allClausesHaveStrictSeq(plan) {
+		if exec := diagnosticsFromContext(ctx); exec != nil {
+			if !allSingleExpansionInSameField(plan) {
+				exec.setReasonIfEmpty("wand_multiple_expansions_or_fields")
+			} else {
+				exec.setReasonIfEmpty("wand_non_strict_seq")
+			}
+		}
 		return nil, false, nil
+	}
+	if exec := diagnosticsFromContext(ctx); exec != nil {
+		exec.setStrategy("bool_or_wand")
 	}
 
 	clauses := make([]*wandClause, 0, len(plan))

--- a/pkg/ftsstats/search_stats.go
+++ b/pkg/ftsstats/search_stats.go
@@ -83,7 +83,7 @@ func (s *SearchStats) ObserveSearch(query string, d *fts.QueryDiagnostics, err e
 		event.LogicalQueryType = d.LogicalQueryType
 		event.ExecutionStrategy = d.ExecutionStrategy
 		event.StrategySkipReason = d.StrategySkipReason
-		event.TotalDuration = d.Timings["total"]
+		event.TotalDuration = d.Timings.Total
 		event.PostingEntriesRead = d.PostingEntriesRead
 		event.MatchedDocs = d.MatchedDocs
 		event.ReturnedDocs = d.ReturnedDocs
@@ -109,10 +109,10 @@ func (s *SearchStats) ObserveSearch(query string, d *fts.QueryDiagnostics, err e
 		}
 		st := s.byStrategy[strategy]
 		st.Count++
-		st.CumulativeDuration += d.Timings["total"]
+		st.CumulativeDuration += d.Timings.Total
 		st.TotalPostings += d.PostingEntriesRead
-		if d.Timings["total"] > st.MaxDuration {
-			st.MaxDuration = d.Timings["total"]
+		if d.Timings.Total > st.MaxDuration {
+			st.MaxDuration = d.Timings.Total
 		}
 		s.byStrategy[strategy] = st
 	}

--- a/pkg/ftsstats/search_stats.go
+++ b/pkg/ftsstats/search_stats.go
@@ -73,12 +73,21 @@ func NewSearchStats(recentLimit int) *SearchStats {
 	}
 }
 
-func (s *SearchStats) ObserveSearch(query string, d *fts.QueryDiagnostics, err error) {
+func (s *SearchStats) ObserveResult(query string, res *fts.SearchResult, err error) {
 	if s == nil {
 		return
 	}
 
 	event := SearchEvent{At: time.Now(), QueryHash: queryHash(query)}
+	if res != nil {
+		event.MatchedDocs = res.TotalResultsCount
+		event.ReturnedDocs = len(res.Results)
+	}
+
+	var d *fts.QueryDiagnostics
+	if res != nil {
+		d = res.Diagnostics
+	}
 	if d != nil {
 		event.LogicalQueryType = d.LogicalQueryType
 		event.ExecutionStrategy = d.ExecutionStrategy
@@ -99,7 +108,7 @@ func (s *SearchStats) ObserveSearch(query string, d *fts.QueryDiagnostics, err e
 	if err != nil {
 		s.errorsTotal++
 	}
-	if d != nil && d.MatchedDocs == 0 {
+	if res != nil && res.TotalResultsCount == 0 {
 		s.zeroResults++
 	}
 	if d != nil {

--- a/pkg/ftsstats/search_stats.go
+++ b/pkg/ftsstats/search_stats.go
@@ -1,4 +1,4 @@
-package observability
+package ftsstats
 
 import (
 	"crypto/sha256"

--- a/pkg/ftsstats/search_stats_test.go
+++ b/pkg/ftsstats/search_stats_test.go
@@ -17,7 +17,7 @@ func TestSearchStatsObserveAggregatesByStrategy(t *testing.T) {
 		PostingEntriesRead: 12,
 		MatchedDocs:        3,
 		ReturnedDocs:       2,
-		Timings:            map[string]time.Duration{"total": 8 * time.Millisecond},
+		Timings:            fts.QueryTimings{Total: 8 * time.Millisecond},
 	}, nil)
 	stats.ObserveSearch("alpha", &fts.QueryDiagnostics{
 		LogicalQueryType:   "term",
@@ -25,7 +25,7 @@ func TestSearchStatsObserveAggregatesByStrategy(t *testing.T) {
 		PostingEntriesRead: 4,
 		MatchedDocs:        0,
 		ReturnedDocs:       0,
-		Timings:            map[string]time.Duration{"total": 2 * time.Millisecond},
+		Timings:            fts.QueryTimings{Total: 2 * time.Millisecond},
 	}, nil)
 
 	snap := stats.Snapshot()
@@ -76,9 +76,9 @@ func TestSearchStatsObserveErrorWithoutDiagnostics(t *testing.T) {
 
 func TestSearchStatsRecentLimit(t *testing.T) {
 	stats := NewSearchStats(2)
-	stats.ObserveSearch("one", &fts.QueryDiagnostics{Timings: map[string]time.Duration{}}, nil)
-	stats.ObserveSearch("two", &fts.QueryDiagnostics{Timings: map[string]time.Duration{}}, nil)
-	stats.ObserveSearch("three", &fts.QueryDiagnostics{Timings: map[string]time.Duration{}}, nil)
+	stats.ObserveSearch("one", &fts.QueryDiagnostics{Timings: fts.QueryTimings{}}, nil)
+	stats.ObserveSearch("two", &fts.QueryDiagnostics{Timings: fts.QueryTimings{}}, nil)
+	stats.ObserveSearch("three", &fts.QueryDiagnostics{Timings: fts.QueryTimings{}}, nil)
 
 	recent := stats.Recent(2)
 	if len(recent) != 2 {

--- a/pkg/ftsstats/search_stats_test.go
+++ b/pkg/ftsstats/search_stats_test.go
@@ -10,22 +10,30 @@ import (
 
 func TestSearchStatsObserveAggregatesByStrategy(t *testing.T) {
 	stats := NewSearchStats(4)
-	stats.ObserveSearch("alpha beta", &fts.QueryDiagnostics{
-		LogicalQueryType:   "boolean",
-		ExecutionStrategy:  "bool_or_wand",
-		StrategySkipReason: "and_fast_no_must_terms",
-		PostingEntriesRead: 12,
-		MatchedDocs:        3,
-		ReturnedDocs:       2,
-		Timings:            fts.QueryTimings{Total: 8 * time.Millisecond},
+	stats.ObserveResult("alpha beta", &fts.SearchResult{
+		Results:           []fts.Result{{ID: "doc-1"}, {ID: "doc-2"}},
+		TotalResultsCount: 3,
+		Diagnostics: &fts.QueryDiagnostics{
+			LogicalQueryType:   "boolean",
+			ExecutionStrategy:  "bool_or_wand",
+			StrategySkipReason: "and_fast_no_must_terms",
+			PostingEntriesRead: 12,
+			MatchedDocs:        3,
+			ReturnedDocs:       2,
+			Timings:            fts.QueryTimings{Total: 8 * time.Millisecond},
+		},
 	}, nil)
-	stats.ObserveSearch("alpha", &fts.QueryDiagnostics{
-		LogicalQueryType:   "term",
-		ExecutionStrategy:  "term",
-		PostingEntriesRead: 4,
-		MatchedDocs:        0,
-		ReturnedDocs:       0,
-		Timings:            fts.QueryTimings{Total: 2 * time.Millisecond},
+	stats.ObserveResult("alpha", &fts.SearchResult{
+		Results:           nil,
+		TotalResultsCount: 0,
+		Diagnostics: &fts.QueryDiagnostics{
+			LogicalQueryType:   "term",
+			ExecutionStrategy:  "term",
+			PostingEntriesRead: 4,
+			MatchedDocs:        0,
+			ReturnedDocs:       0,
+			Timings:            fts.QueryTimings{Total: 2 * time.Millisecond},
+		},
 	}, nil)
 
 	snap := stats.Snapshot()
@@ -58,9 +66,31 @@ func TestSearchStatsObserveAggregatesByStrategy(t *testing.T) {
 	}
 }
 
+func TestSearchStatsObserveResultWithoutDiagnostics(t *testing.T) {
+	stats := NewSearchStats(2)
+	stats.ObserveResult("alpha", &fts.SearchResult{Results: []fts.Result{{ID: "doc-1"}}, TotalResultsCount: 2}, nil)
+
+	snap := stats.Snapshot()
+	if snap.TotalSearches != 1 || snap.ErrorsTotal != 0 || snap.ZeroResults != 0 {
+		t.Fatalf("unexpected snapshot totals: %+v", snap)
+	}
+	if len(snap.ByStrategy) != 0 {
+		t.Fatalf("ByStrategy = %+v, want empty", snap.ByStrategy)
+	}
+	if len(snap.Recent) != 1 {
+		t.Fatalf("Recent len = %d, want 1", len(snap.Recent))
+	}
+	if snap.Recent[0].MatchedDocs != 2 || snap.Recent[0].ReturnedDocs != 1 {
+		t.Fatalf("unexpected recent event: %+v", snap.Recent[0])
+	}
+	if snap.Recent[0].ExecutionStrategy != "" || snap.Recent[0].TotalDuration != 0 {
+		t.Fatalf("expected no diagnostics-derived fields, got %+v", snap.Recent[0])
+	}
+}
+
 func TestSearchStatsObserveErrorWithoutDiagnostics(t *testing.T) {
 	stats := NewSearchStats(2)
-	stats.ObserveSearch("broken", nil, errors.New("boom"))
+	stats.ObserveResult("broken", nil, errors.New("boom"))
 
 	snap := stats.Snapshot()
 	if snap.TotalSearches != 1 || snap.ErrorsTotal != 1 {
@@ -76,9 +106,9 @@ func TestSearchStatsObserveErrorWithoutDiagnostics(t *testing.T) {
 
 func TestSearchStatsRecentLimit(t *testing.T) {
 	stats := NewSearchStats(2)
-	stats.ObserveSearch("one", &fts.QueryDiagnostics{Timings: fts.QueryTimings{}}, nil)
-	stats.ObserveSearch("two", &fts.QueryDiagnostics{Timings: fts.QueryTimings{}}, nil)
-	stats.ObserveSearch("three", &fts.QueryDiagnostics{Timings: fts.QueryTimings{}}, nil)
+	stats.ObserveResult("one", &fts.SearchResult{}, nil)
+	stats.ObserveResult("two", &fts.SearchResult{}, nil)
+	stats.ObserveResult("three", &fts.SearchResult{}, nil)
 
 	recent := stats.Recent(2)
 	if len(recent) != 2 {

--- a/pkg/ftsstats/search_stats_test.go
+++ b/pkg/ftsstats/search_stats_test.go
@@ -1,4 +1,4 @@
-package observability
+package ftsstats
 
 import (
 	"errors"

--- a/pkg/index/hamt/bench_test.go
+++ b/pkg/index/hamt/bench_test.go
@@ -1,0 +1,50 @@
+package hamt
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/dariasmyr/fts-engine/pkg/fts"
+)
+
+func benchmarkIndex(b *testing.B, terms int, docs int) *Index {
+	b.Helper()
+	idx := New()
+	rng := rand.New(rand.NewSource(42))
+	words := make([]string, terms)
+	for i := range words {
+		words[i] = fmt.Sprintf("word%04d", i)
+	}
+	for doc := 0; doc < docs; doc++ {
+		docID := fts.DocID(fmt.Sprintf("doc-%d", doc))
+		for j := 0; j < 20; j++ {
+			if err := idx.Insert(words[rng.Intn(len(words))], docID); err != nil {
+				b.Fatalf("Insert() error = %v", err)
+			}
+		}
+	}
+	return idx
+}
+
+func BenchmarkInsert(b *testing.B) {
+	idx := New()
+	for i := 0; b.Loop(); i++ {
+		if err := idx.Insert(fmt.Sprintf("word%06d", i), fts.DocID(fmt.Sprintf("doc-%d", i))); err != nil {
+			b.Fatalf("Insert() error = %v", err)
+		}
+	}
+}
+
+func BenchmarkSearch(b *testing.B) {
+	idx := benchmarkIndex(b, 500, 500)
+	query := "word0001"
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := idx.Search(query)
+		if err != nil {
+			b.Fatalf("Search() error = %v", err)
+		}
+	}
+}

--- a/pkg/index/hamt/bench_test.go
+++ b/pkg/index/hamt/bench_test.go
@@ -27,11 +27,39 @@ func benchmarkIndex(b *testing.B, terms int, docs int) *Index {
 	return idx
 }
 
+func benchmarkPositionalIndex(b *testing.B, terms int, docs int) *Index {
+	b.Helper()
+	idx := New()
+	rng := rand.New(rand.NewSource(42))
+	words := make([]string, terms)
+	for i := range words {
+		words[i] = fmt.Sprintf("word%04d", i)
+	}
+	for doc := 0; doc < docs; doc++ {
+		docID := fts.DocID(fmt.Sprintf("doc-%d", doc))
+		for pos := 0; pos < 20; pos++ {
+			if err := idx.InsertAt(words[rng.Intn(len(words))], docID, uint32(pos)); err != nil {
+				b.Fatalf("InsertAt() error = %v", err)
+			}
+		}
+	}
+	return idx
+}
+
 func BenchmarkInsert(b *testing.B) {
 	idx := New()
 	for i := 0; b.Loop(); i++ {
 		if err := idx.Insert(fmt.Sprintf("word%06d", i), fts.DocID(fmt.Sprintf("doc-%d", i))); err != nil {
 			b.Fatalf("Insert() error = %v", err)
+		}
+	}
+}
+
+func BenchmarkInsertAt(b *testing.B) {
+	idx := New()
+	for i := 0; b.Loop(); i++ {
+		if err := idx.InsertAt(fmt.Sprintf("word%06d", i), fts.DocID(fmt.Sprintf("doc-%d", i)), uint32(i%20)); err != nil {
+			b.Fatalf("InsertAt() error = %v", err)
 		}
 	}
 }
@@ -45,6 +73,19 @@ func BenchmarkSearch(b *testing.B) {
 		_, err := idx.Search(query)
 		if err != nil {
 			b.Fatalf("Search() error = %v", err)
+		}
+	}
+}
+
+func BenchmarkSearchPositional(b *testing.B) {
+	idx := benchmarkPositionalIndex(b, 500, 500)
+	query := "word0001"
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := idx.SearchPositional(query)
+		if err != nil {
+			b.Fatalf("SearchPositional() error = %v", err)
 		}
 	}
 }

--- a/pkg/index/hamtpointered/bench_test.go
+++ b/pkg/index/hamtpointered/bench_test.go
@@ -1,0 +1,50 @@
+package hamtpointered
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/dariasmyr/fts-engine/pkg/fts"
+)
+
+func benchmarkIndex(b *testing.B, terms int, docs int) *Index {
+	b.Helper()
+	idx := New()
+	rng := rand.New(rand.NewSource(42))
+	words := make([]string, terms)
+	for i := range words {
+		words[i] = fmt.Sprintf("word%04d", i)
+	}
+	for doc := 0; doc < docs; doc++ {
+		docID := fts.DocID(fmt.Sprintf("doc-%d", doc))
+		for j := 0; j < 20; j++ {
+			if err := idx.Insert(words[rng.Intn(len(words))], docID); err != nil {
+				b.Fatalf("Insert() error = %v", err)
+			}
+		}
+	}
+	return idx
+}
+
+func BenchmarkInsert(b *testing.B) {
+	idx := New()
+	for i := 0; b.Loop(); i++ {
+		if err := idx.Insert(fmt.Sprintf("word%06d", i), fts.DocID(fmt.Sprintf("doc-%d", i))); err != nil {
+			b.Fatalf("Insert() error = %v", err)
+		}
+	}
+}
+
+func BenchmarkSearch(b *testing.B) {
+	idx := benchmarkIndex(b, 500, 500)
+	query := "word0001"
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := idx.Search(query)
+		if err != nil {
+			b.Fatalf("Search() error = %v", err)
+		}
+	}
+}

--- a/pkg/index/hamtpointered/bench_test.go
+++ b/pkg/index/hamtpointered/bench_test.go
@@ -27,11 +27,39 @@ func benchmarkIndex(b *testing.B, terms int, docs int) *Index {
 	return idx
 }
 
+func benchmarkPositionalIndex(b *testing.B, terms int, docs int) *Index {
+	b.Helper()
+	idx := New()
+	rng := rand.New(rand.NewSource(42))
+	words := make([]string, terms)
+	for i := range words {
+		words[i] = fmt.Sprintf("word%04d", i)
+	}
+	for doc := 0; doc < docs; doc++ {
+		docID := fts.DocID(fmt.Sprintf("doc-%d", doc))
+		for pos := 0; pos < 20; pos++ {
+			if err := idx.InsertAt(words[rng.Intn(len(words))], docID, uint32(pos)); err != nil {
+				b.Fatalf("InsertAt() error = %v", err)
+			}
+		}
+	}
+	return idx
+}
+
 func BenchmarkInsert(b *testing.B) {
 	idx := New()
 	for i := 0; b.Loop(); i++ {
 		if err := idx.Insert(fmt.Sprintf("word%06d", i), fts.DocID(fmt.Sprintf("doc-%d", i))); err != nil {
 			b.Fatalf("Insert() error = %v", err)
+		}
+	}
+}
+
+func BenchmarkInsertAt(b *testing.B) {
+	idx := New()
+	for i := 0; b.Loop(); i++ {
+		if err := idx.InsertAt(fmt.Sprintf("word%06d", i), fts.DocID(fmt.Sprintf("doc-%d", i)), uint32(i%20)); err != nil {
+			b.Fatalf("InsertAt() error = %v", err)
 		}
 	}
 }
@@ -45,6 +73,19 @@ func BenchmarkSearch(b *testing.B) {
 		_, err := idx.Search(query)
 		if err != nil {
 			b.Fatalf("Search() error = %v", err)
+		}
+	}
+}
+
+func BenchmarkSearchPositional(b *testing.B) {
+	idx := benchmarkPositionalIndex(b, 500, 500)
+	query := "word0001"
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := idx.SearchPositional(query)
+		if err != nil {
+			b.Fatalf("SearchPositional() error = %v", err)
 		}
 	}
 }

--- a/pkg/index/radix/bench_test.go
+++ b/pkg/index/radix/bench_test.go
@@ -27,11 +27,39 @@ func benchmarkIndex(b *testing.B, terms int, docs int) *Index {
 	return idx
 }
 
+func benchmarkPositionalIndex(b *testing.B, terms int, docs int) *Index {
+	b.Helper()
+	idx := New()
+	rng := rand.New(rand.NewSource(42))
+	words := make([]string, terms)
+	for i := range words {
+		words[i] = fmt.Sprintf("word%04d", i)
+	}
+	for doc := 0; doc < docs; doc++ {
+		docID := fts.DocID(fmt.Sprintf("doc-%d", doc))
+		for pos := 0; pos < 20; pos++ {
+			if err := idx.InsertAt(words[rng.Intn(len(words))], docID, uint32(pos)); err != nil {
+				b.Fatalf("InsertAt() error = %v", err)
+			}
+		}
+	}
+	return idx
+}
+
 func BenchmarkInsert(b *testing.B) {
 	idx := New()
 	for i := 0; b.Loop(); i++ {
 		if err := idx.Insert(fmt.Sprintf("word%06d", i), fts.DocID(fmt.Sprintf("doc-%d", i))); err != nil {
 			b.Fatalf("Insert() error = %v", err)
+		}
+	}
+}
+
+func BenchmarkInsertAt(b *testing.B) {
+	idx := New()
+	for i := 0; b.Loop(); i++ {
+		if err := idx.InsertAt(fmt.Sprintf("word%06d", i), fts.DocID(fmt.Sprintf("doc-%d", i)), uint32(i%20)); err != nil {
+			b.Fatalf("InsertAt() error = %v", err)
 		}
 	}
 }
@@ -45,6 +73,19 @@ func BenchmarkSearch(b *testing.B) {
 		_, err := idx.Search(query)
 		if err != nil {
 			b.Fatalf("Search() error = %v", err)
+		}
+	}
+}
+
+func BenchmarkSearchPositional(b *testing.B) {
+	idx := benchmarkPositionalIndex(b, 500, 500)
+	query := "word0001"
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := idx.SearchPositional(query)
+		if err != nil {
+			b.Fatalf("SearchPositional() error = %v", err)
 		}
 	}
 }

--- a/pkg/index/radix/bench_test.go
+++ b/pkg/index/radix/bench_test.go
@@ -1,0 +1,50 @@
+package radix
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/dariasmyr/fts-engine/pkg/fts"
+)
+
+func benchmarkIndex(b *testing.B, terms int, docs int) *Index {
+	b.Helper()
+	idx := New()
+	rng := rand.New(rand.NewSource(42))
+	words := make([]string, terms)
+	for i := range words {
+		words[i] = fmt.Sprintf("word%04d", i)
+	}
+	for doc := 0; doc < docs; doc++ {
+		docID := fts.DocID(fmt.Sprintf("doc-%d", doc))
+		for j := 0; j < 20; j++ {
+			if err := idx.Insert(words[rng.Intn(len(words))], docID); err != nil {
+				b.Fatalf("Insert() error = %v", err)
+			}
+		}
+	}
+	return idx
+}
+
+func BenchmarkInsert(b *testing.B) {
+	idx := New()
+	for i := 0; b.Loop(); i++ {
+		if err := idx.Insert(fmt.Sprintf("word%06d", i), fts.DocID(fmt.Sprintf("doc-%d", i))); err != nil {
+			b.Fatalf("Insert() error = %v", err)
+		}
+	}
+}
+
+func BenchmarkSearch(b *testing.B) {
+	idx := benchmarkIndex(b, 500, 500)
+	query := "word0001"
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := idx.Search(query)
+		if err != nil {
+			b.Fatalf("Search() error = %v", err)
+		}
+	}
+}

--- a/pkg/index/slicedradix/bench_test.go
+++ b/pkg/index/slicedradix/bench_test.go
@@ -27,11 +27,39 @@ func benchmarkIndex(b *testing.B, terms int, docs int) *Index {
 	return idx
 }
 
+func benchmarkPositionalIndex(b *testing.B, terms int, docs int) *Index {
+	b.Helper()
+	idx := New()
+	rng := rand.New(rand.NewSource(42))
+	words := make([]string, terms)
+	for i := range words {
+		words[i] = fmt.Sprintf("word%04d", i)
+	}
+	for doc := 0; doc < docs; doc++ {
+		docID := fts.DocID(fmt.Sprintf("doc-%d", doc))
+		for pos := 0; pos < 20; pos++ {
+			if err := idx.InsertAt(words[rng.Intn(len(words))], docID, uint32(pos)); err != nil {
+				b.Fatalf("InsertAt() error = %v", err)
+			}
+		}
+	}
+	return idx
+}
+
 func BenchmarkInsert(b *testing.B) {
 	idx := New()
 	for i := 0; b.Loop(); i++ {
 		if err := idx.Insert(fmt.Sprintf("word%06d", i), fts.DocID(fmt.Sprintf("doc-%d", i))); err != nil {
 			b.Fatalf("Insert() error = %v", err)
+		}
+	}
+}
+
+func BenchmarkInsertAt(b *testing.B) {
+	idx := New()
+	for i := 0; b.Loop(); i++ {
+		if err := idx.InsertAt(fmt.Sprintf("word%06d", i), fts.DocID(fmt.Sprintf("doc-%d", i)), uint32(i%20)); err != nil {
+			b.Fatalf("InsertAt() error = %v", err)
 		}
 	}
 }
@@ -45,6 +73,19 @@ func BenchmarkSearch(b *testing.B) {
 		_, err := idx.Search(query)
 		if err != nil {
 			b.Fatalf("Search() error = %v", err)
+		}
+	}
+}
+
+func BenchmarkSearchPositional(b *testing.B) {
+	idx := benchmarkPositionalIndex(b, 500, 500)
+	query := "word0001"
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := idx.SearchPositional(query)
+		if err != nil {
+			b.Fatalf("SearchPositional() error = %v", err)
 		}
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -224,7 +224,7 @@ Among the built-in public indexes, `slicedradix` currently supports prefix searc
 
 ### 6) Diagnostics and aggregated stats
 
-All regular search methods already return structured per-request diagnostics via `SearchResult.Diagnostics`.
+Per-request diagnostics are opt-in. Regular search methods return `SearchResult.Diagnostics == nil` unless you enable diagnostics for the request context with `fts.WithDiagnostics(ctx)`.
 
 Useful methods include:
 
@@ -239,12 +239,13 @@ Useful methods include:
 Example:
 
 ```go
-res, _ := engine.SearchDocuments(context.Background(), "postgres wal checkpoint", 10)
+ctx := fts.WithDiagnostics(context.Background())
+res, _ := engine.SearchDocuments(ctx, "postgres wal checkpoint", 10)
 
 fmt.Println(res.Diagnostics.LogicalQueryType)
 fmt.Println(res.Diagnostics.ExecutionStrategy)
 fmt.Println(res.Diagnostics.StrategySkipReason)
-fmt.Println(res.Diagnostics.Timings["total"])
+fmt.Println(res.Diagnostics.Timings.Total)
 fmt.Println(res.Diagnostics.PostingEntriesRead)
 ```
 
@@ -270,8 +271,9 @@ func main() {
 	_ = engine.IndexDocument(context.Background(), "doc-1", "postgres wal checkpoint tuning")
 	_ = engine.IndexDocument(context.Background(), "doc-2", "checkpoint and recovery internals")
 
-	res, err := engine.SearchDocuments(context.Background(), "postgres checkpoint", 10)
-	stats.ObserveSearch("postgres checkpoint", res.Diagnostics, err)
+	ctx := fts.WithDiagnostics(context.Background())
+	res, err := engine.SearchDocuments(ctx, "postgres checkpoint", 10)
+	stats.ObserveResult("postgres checkpoint", res, err)
 
 	snap := stats.Snapshot()
 	for strategy, st := range snap.ByStrategy {
@@ -289,6 +291,8 @@ func main() {
 - recent search events without storing raw query text by default;
 - aggregated stats by execution strategy;
 - structured observability without depending on `cmd/fts` or any HTTP/debug transport layer.
+
+`ObserveResult(...)` is tolerant: it always records base request/error information, uses `SearchResult` fields like `TotalResultsCount` and returned hit count even when diagnostics are disabled, and fills diagnostics-dependent fields only when `res.Diagnostics` is non-nil.
 
 ## Run main app (local testing via config)
 

--- a/readme.md
+++ b/readme.md
@@ -310,6 +310,8 @@ Snapshot fields (`fts.snapshot`):
 
 Use `cmd/bench` when you want to compare index/scorer/pipeline combinations on a corpus with labeled queries.
 
+In addition to indexing time and search quality metrics, `cmd/bench` now also reports aggregated search diagnostics such as strategy distribution, diagnostics timings, posting reads, and index lookups.
+
 Example:
 
 ```bash
@@ -332,6 +334,141 @@ Useful flags:
 - `-k`: top-k used for `nDCG` and `Recall`
 - `-limit`: cap the number of indexed documents for quick experiments
 - `-worst`: print worst queries by `nDCG`
+
+### Benchmark baselines
+
+For fair before/after comparisons keep these flags unchanged between runs:
+
+- `-limit`
+- `-index`
+- `-lang`
+- `-field`
+- `-scorer`
+- `-k`
+
+Engine microbench:
+
+```bash
+go test -run '^$' -bench . -benchmem -count=5 ./pkg/fts | tee before-engine.txt
+```
+
+Index microbench:
+
+```bash
+go test -run '^$' -bench . -benchmem -count=5 \
+  ./pkg/index/radix \
+  ./pkg/index/slicedradix \
+  ./pkg/index/hamt \
+  ./pkg/index/hamtpointered | tee before-indexes.txt
+```
+
+Full microbench run:
+
+```bash
+go test -run '^$' -bench . -benchmem -count=5 \
+  ./pkg/fts \
+  ./pkg/index/radix \
+  ./pkg/index/slicedradix \
+  ./pkg/index/hamt \
+  ./pkg/index/hamtpointered | tee before-micro-all.txt
+```
+
+Fast end-to-end bench on a local dump, for example `./data/enwiki-latest-abstract1.xml.gz`:
+
+```bash
+go run ./cmd/bench \
+  -dump ./data/enwiki-latest-abstract1.xml.gz \
+  -ground-truth ./internal/bench/testdata/queries.sample.json \
+  -index slicedradix \
+  -lang en \
+  -field abstract \
+  -scorer bm25 \
+  -k 10 \
+  -limit 5000 \
+  -worst 5 | tee before-e2e-fast.txt
+```
+
+Medium end-to-end bench:
+
+```bash
+go run ./cmd/bench \
+  -dump ./data/enwiki-latest-abstract1.xml.gz \
+  -ground-truth ./internal/bench/testdata/queries.sample.json \
+  -index slicedradix \
+  -lang en \
+  -field abstract \
+  -scorer bm25 \
+  -k 10 \
+  -limit 20000 \
+  -worst 10 | tee before-e2e-medium.txt
+```
+
+To compare index implementations on the same corpus, rerun `cmd/bench` with the same flags and vary only `-index`:
+
+```bash
+go run ./cmd/bench \
+  -dump ./data/enwiki-latest-abstract1.xml.gz \
+  -ground-truth ./internal/bench/testdata/queries.sample.json \
+  -index radix \
+  -lang en \
+  -field abstract \
+  -scorer bm25 \
+  -k 10 \
+  -limit 10000 \
+  -worst 5 | tee before-radix.txt
+```
+
+```bash
+go run ./cmd/bench \
+  -dump ./data/enwiki-latest-abstract1.xml.gz \
+  -ground-truth ./internal/bench/testdata/queries.sample.json \
+  -index slicedradix \
+  -lang en \
+  -field abstract \
+  -scorer bm25 \
+  -k 10 \
+  -limit 10000 \
+  -worst 5 | tee before-slicedradix.txt
+```
+
+```bash
+go run ./cmd/bench \
+  -dump ./data/enwiki-latest-abstract1.xml.gz \
+  -ground-truth ./internal/bench/testdata/queries.sample.json \
+  -index hamt \
+  -lang en \
+  -field abstract \
+  -scorer bm25 \
+  -k 10 \
+  -limit 10000 \
+  -worst 5 | tee before-hamt.txt
+```
+
+```bash
+go run ./cmd/bench \
+  -dump ./data/enwiki-latest-abstract1.xml.gz \
+  -ground-truth ./internal/bench/testdata/queries.sample.json \
+  -index hamtpointered \
+  -lang en \
+  -field abstract \
+  -scorer bm25 \
+  -k 10 \
+  -limit 10000 \
+  -worst 5 | tee before-hamtpointered.txt
+```
+
+Recommended minimum baseline before a feature branch:
+
+1. Run the engine microbench.
+2. Run the index microbench.
+3. Run the fast end-to-end bench.
+
+After the change, rerun the same commands and save results into `after-*` files.
+
+Compare these outputs:
+
+- microbench: `ns/op`, `B/op`, `allocs/op`
+- `cmd/bench`: indexing duration, latency `p50/p95/p99`, `diag.total`, `diag.search_tokens`, `avg postings`, `avg index_lookups`, strategy distribution, `nDCG`, `MRR`, `Recall`
 
 ## Ribbon filter usage
 
@@ -464,8 +601,8 @@ Run only public packages:
 go test ./pkg/...
 ```
 
-Run microbenchmarks for the FTS engine and prefix-capable sliced radix index:
+Run microbenchmarks for the FTS engine and all current index implementations:
 
 ```bash
-go test -bench=. ./pkg/fts ./pkg/index/slicedradix
+go test -run '^$' -bench . -benchmem ./pkg/fts ./pkg/index/radix ./pkg/index/slicedradix ./pkg/index/hamt ./pkg/index/hamtpointered
 ```

--- a/readme.md
+++ b/readme.md
@@ -379,52 +379,51 @@ Snapshot fields (`fts.snapshot`):
   - always indexes current input and prints memory/index stats,
   - does not run CUI snapshot restore flow.
 
-## Bench CLI
+## Benchmarks
 
-Use `cmd/bench` when you want to compare index/scorer/pipeline combinations on a corpus with labeled queries.
+This repository uses three benchmark types:
 
-In addition to indexing time and search quality metrics, `cmd/bench` can also report aggregated search diagnostics such as strategy distribution, diagnostics timings, posting reads, and index lookups. It also supports repeated runs with warmup and shuffled query order for more stable latency comparisons.
+- end-to-end bench: `go run ./cmd/bench ...`
+- engine microbench: `go test -run '^$' -bench . ./pkg/fts`
+- index microbench: `go test -run '^$' -bench . ./pkg/index/...`
 
-Example:
+Use `tee file.txt` when you want to both see benchmark output in the terminal and save the same output into a file for before/after comparison.
 
-```bash
-go run ./cmd/bench \
-  -dump ./data/enwiki-latest-abstract.xml.gz \
-  -ground-truth ./internal/bench/testdata/queries.sample.json \
-  -index slicedradix \
-  -lang en \
-  -field abstract \
-  -scorer bm25 \
-  -k 10 \
-  -diagnostics true \
-  -observer false \
-  -warmup 20 \
-  -repeat 5 \
-  -shuffle true
-```
+### 1) End-to-End Bench
 
-Useful flags:
+Use `cmd/bench` when you want to compare index, scorer, and pipeline combinations on a corpus with labeled queries.
 
+It measures:
+
+- indexing duration
+- search latency `p50/p95/p99`
+- quality metrics: `nDCG`, `MRR`, `Recall`
+- optional diagnostics: `diag.total`, `diag.search_tokens`, strategy distribution, posting reads, index lookups
+
+Common flags:
+
+- `-dump`: wiki dump path
+- `-ground-truth`: labeled query set path
 - `-index`: `radix|slicedradix|hamt|hamtpointered`
 - `-lang`: `en|ru|multi|none`
 - `-field`: `abstract|extract|title`
 - `-scorer`: `simple|bm25|tfidf`
 - `-k`: top-k used for `nDCG` and `Recall`
 - `-limit`: cap the number of indexed documents for quick experiments
-- `-worst`: print worst queries by `nDCG`
+- `-worst`: print worst queries by `nDCG` and slowest queries by latency
 - `-diagnostics`: enable per-query `SearchResult.Diagnostics`
 - `-observer`: enable `ftsstats.SearchStats` aggregation during the benchmark run
 - `-warmup`: run N warmup searches before measured runs; warmup does not affect reported metrics
 - `-repeat`: repeat the full query set N times for measured runs
 - `-shuffle`: shuffle query order for warmup and each measured repeat with a fixed seed
 
-Local shard workloads checked in under `internal/bench/testdata/`:
+Local workloads checked in under `internal/bench/testdata/`:
 
 - `queries.abstract1.title.json`: tiny sanity-check workload for `-field title`
 - `queries.abstract1.abstract.json`: tiny sanity-check workload for `-field abstract`
 - `queries.abstract1.abstract.50.json`: curated 50-query `abstract` workload for repeated latency comparisons
 
-For local instrumentation comparisons on `./data/enwiki-20210820-abstract1.xml.gz`, use the curated 50-query abstract set:
+Steady-state example:
 
 ```bash
 go run ./cmd/bench \
@@ -439,10 +438,10 @@ go run ./cmd/bench \
   -repeat 20 \
   -shuffle true \
   -diagnostics false \
-  -observer false
+  -observer false | tee before-e2e.txt
 ```
 
-To compare instrumentation overhead, rerun the same command and vary only `-diagnostics` and `-observer`:
+Cold-run example:
 
 ```bash
 go run ./cmd/bench \
@@ -453,68 +452,62 @@ go run ./cmd/bench \
   -field abstract \
   -scorer simple \
   -k 10 \
-  -warmup 50 \
-  -repeat 20 \
-  -shuffle true \
-  -diagnostics true \
-  -observer false
-```
-
-```bash
-go run ./cmd/bench \
-  -dump ./data/enwiki-20210820-abstract1.xml.gz \
-  -ground-truth ./internal/bench/testdata/queries.abstract1.abstract.50.json \
-  -index radix \
-  -lang en \
-  -field abstract \
-  -scorer simple \
-  -k 10 \
-  -warmup 50 \
-  -repeat 20 \
-  -shuffle true \
+  -warmup 0 \
+  -repeat 1 \
+  -shuffle false \
   -diagnostics false \
-  -observer true
+  -observer false | tee before-e2e-cold.txt
 ```
 
-```bash
-go run ./cmd/bench \
-  -dump ./data/enwiki-20210820-abstract1.xml.gz \
-  -ground-truth ./internal/bench/testdata/queries.abstract1.abstract.50.json \
-  -index radix \
-  -lang en \
-  -field abstract \
-  -scorer simple \
-  -k 10 \
-  -warmup 50 \
-  -repeat 20 \
-  -shuffle true \
-  -diagnostics true \
-  -observer true
-```
+This keeps the first measured pass cold inside a fresh `cmd/bench` process. If you rerun the command, treat each process start as a separate cold run.
+
+To compare instrumentation overhead, keep all other flags the same and vary only:
+
+- `-diagnostics`
+- `-observer`
+
+To compare index implementations on the same corpus, keep all other flags the same and vary only:
+
+- `-index`
 
 Current latency numbers are measured around `SearchDocuments(...)`. `-observer` still exercises the observer path and prints observer summary, but observer work is not included in the reported `latency p50/p95/p99` yet.
 
-### Benchmark baselines
+### 2) Engine Microbench
 
-For fair before/after comparisons keep these flags unchanged between runs:
+Use the engine microbench when you want to measure the `pkg/fts` search engine in isolation from the end-to-end CLI flow.
 
-- `-limit`
-- `-index`
-- `-lang`
-- `-field`
-- `-scorer`
-- `-k`
-- `-warmup`
-- `-repeat`
-- `-shuffle`
+It typically measures:
 
-Engine microbench:
+- `ns/op`
+- `B/op`
+- `allocs/op`
+
+Useful `go test` flags:
+
+- `-bench .`: run all benchmarks in the package
+- `-benchmem`: print allocation stats
+- `-count=5`: repeat the benchmark 5 times
+- `-run '^$'`: skip regular unit tests
+
+Example:
 
 ```bash
 go test -run '^$' -bench . -benchmem -count=5 ./pkg/fts | tee before-engine.txt
 ```
 
-Index microbench:
+### 3) Index Microbench
+
+Use the index microbench when you want to measure low-level index operations in the concrete index implementations.
+
+It typically measures:
+
+- index lookup cost
+- insert cost
+- allocations per operation
+
+It uses the same `go test` flags as the engine microbench.
+
+Example across all current public indexes:
 
 ```bash
 go test -run '^$' -bench . -benchmem -count=5 \
@@ -524,7 +517,7 @@ go test -run '^$' -bench . -benchmem -count=5 \
   ./pkg/index/hamtpointered | tee before-indexes.txt
 ```
 
-Full microbench run:
+If you want one command that runs both microbench groups together, use:
 
 ```bash
 go test -run '^$' -bench . -benchmem -count=5 \
@@ -535,97 +528,34 @@ go test -run '^$' -bench . -benchmem -count=5 \
   ./pkg/index/hamtpointered | tee before-micro-all.txt
 ```
 
-Fast end-to-end bench on a local dump, for example `./data/enwiki-latest-abstract1.xml.gz`:
+### Benchmark Baselines
 
-```bash
-go run ./cmd/bench \
-  -dump ./data/enwiki-latest-abstract1.xml.gz \
-  -ground-truth ./internal/bench/testdata/queries.sample.json \
-  -index slicedradix \
-  -lang en \
-  -field abstract \
-  -scorer bm25 \
-  -k 10 \
-  -limit 5000 \
-  -worst 5 | tee before-e2e-fast.txt
-```
+For fair before/after comparisons:
 
-Medium end-to-end bench:
+1. Run the same benchmark type before the change.
+2. Save the output into `before-*` files.
+3. Rerun the same commands after the change and save them into `after-*` files.
+4. Compare like-for-like outputs only.
 
-```bash
-go run ./cmd/bench \
-  -dump ./data/enwiki-latest-abstract1.xml.gz \
-  -ground-truth ./internal/bench/testdata/queries.sample.json \
-  -index slicedradix \
-  -lang en \
-  -field abstract \
-  -scorer bm25 \
-  -k 10 \
-  -limit 20000 \
-  -worst 10 | tee before-e2e-medium.txt
-```
+For end-to-end comparisons keep these flags unchanged between runs:
 
-To compare index implementations on the same corpus, rerun `cmd/bench` with the same flags and vary only `-index`:
-
-```bash
-go run ./cmd/bench \
-  -dump ./data/enwiki-latest-abstract1.xml.gz \
-  -ground-truth ./internal/bench/testdata/queries.sample.json \
-  -index radix \
-  -lang en \
-  -field abstract \
-  -scorer bm25 \
-  -k 10 \
-  -limit 10000 \
-  -worst 5 | tee before-radix.txt
-```
-
-```bash
-go run ./cmd/bench \
-  -dump ./data/enwiki-latest-abstract1.xml.gz \
-  -ground-truth ./internal/bench/testdata/queries.sample.json \
-  -index slicedradix \
-  -lang en \
-  -field abstract \
-  -scorer bm25 \
-  -k 10 \
-  -limit 10000 \
-  -worst 5 | tee before-slicedradix.txt
-```
-
-```bash
-go run ./cmd/bench \
-  -dump ./data/enwiki-latest-abstract1.xml.gz \
-  -ground-truth ./internal/bench/testdata/queries.sample.json \
-  -index hamt \
-  -lang en \
-  -field abstract \
-  -scorer bm25 \
-  -k 10 \
-  -limit 10000 \
-  -worst 5 | tee before-hamt.txt
-```
-
-```bash
-go run ./cmd/bench \
-  -dump ./data/enwiki-latest-abstract1.xml.gz \
-  -ground-truth ./internal/bench/testdata/queries.sample.json \
-  -index hamtpointered \
-  -lang en \
-  -field abstract \
-  -scorer bm25 \
-  -k 10 \
-  -limit 10000 \
-  -worst 5 | tee before-hamtpointered.txt
-```
+- `-limit`
+- `-index`
+- `-lang`
+- `-field`
+- `-scorer`
+- `-k`
+- `-warmup`
+- `-repeat`
+- `-shuffle`
+- `-diagnostics`
+- `-observer`
 
 Recommended minimum baseline before a feature branch:
 
 1. Run the engine microbench.
-2. Run the index microbench.
-3. Run the fast end-to-end bench.
-
-After the change, rerun the same commands and save results into `after-*` files.
+2. Run the index microbench if you touched index code.
+3. Run the end-to-end bench on a representative local dump.
 
 Compare these outputs:
 

--- a/readme.md
+++ b/readme.md
@@ -208,6 +208,16 @@ res, _ = engine.SearchPhraseFields(context.Background(), []string{"title", "body
 res, _ = engine.SearchPhraseNearFields(context.Background(), []string{"title", "body"}, "barack obama", 1, 10)
 ```
 
+If you want different subqueries for different fields without building the AST manually, use field clauses:
+
+```go
+res, _ := engine.SearchFieldClauses(context.Background(), []fts.FieldQueryClause{
+	fts.MustFieldQuery("title", "barack"),
+	fts.MustFieldQuery("body", `"french hotel"`),
+	fts.MustNotFieldQuery("body", "market"),
+}, 10)
+```
+
 Prefix queries require an index that implements `fts.PrefixIndex`.
 Among the built-in public indexes, `slicedradix` currently supports prefix search.
 

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@ Reusable full-text search engine in Go with configurable indexes, filters, stemm
 - Public text processing pipeline in `pkg/textproc`.
 - Public key generators in `pkg/keygen`.
 - Public probabilistic filters in `pkg/filter`.
+- Public diagnostics observer in `pkg/ftsstats`.
 - CLI entrypoint in `cmd/fts` with:
   - `prod` mode (run with configurable filters and interactive CUI)
   - `experiment` mode (collect indexing metrics)
@@ -220,6 +221,74 @@ res, _ := engine.SearchFieldClauses(context.Background(), []fts.FieldQueryClause
 
 Prefix queries require an index that implements `fts.PrefixIndex`.
 Among the built-in public indexes, `slicedradix` currently supports prefix search.
+
+### 6) Diagnostics and aggregated stats
+
+All regular search methods already return structured per-request diagnostics via `SearchResult.Diagnostics`.
+
+Useful methods include:
+
+- `Search(...)`
+- `SearchDocuments(...)`
+- `SearchField(...)`
+- `SearchFields(...)`
+- `SearchFieldClauses(...)`
+- `SearchPhrase(...)`
+- `SearchPhraseNear(...)`
+
+Example:
+
+```go
+res, _ := engine.SearchDocuments(context.Background(), "postgres wal checkpoint", 10)
+
+fmt.Println(res.Diagnostics.LogicalQueryType)
+fmt.Println(res.Diagnostics.ExecutionStrategy)
+fmt.Println(res.Diagnostics.StrategySkipReason)
+fmt.Println(res.Diagnostics.Timings["total"])
+fmt.Println(res.Diagnostics.PostingEntriesRead)
+```
+
+If you want aggregated observability across many requests, use `pkg/ftsstats`.
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dariasmyr/fts-engine/pkg/fts"
+	"github.com/dariasmyr/fts-engine/pkg/ftsstats"
+	"github.com/dariasmyr/fts-engine/pkg/index/radix"
+	"github.com/dariasmyr/fts-engine/pkg/keygen"
+)
+
+func main() {
+	engine := fts.New(radix.New(), keygen.Word)
+	stats := ftsstats.NewSearchStats(64)
+
+	_ = engine.IndexDocument(context.Background(), "doc-1", "postgres wal checkpoint tuning")
+	_ = engine.IndexDocument(context.Background(), "doc-2", "checkpoint and recovery internals")
+
+	res, err := engine.SearchDocuments(context.Background(), "postgres checkpoint", 10)
+	stats.ObserveSearch("postgres checkpoint", res.Diagnostics, err)
+
+	snap := stats.Snapshot()
+	for strategy, st := range snap.ByStrategy {
+		fmt.Println(strategy, st.Count, st.AvgDuration(), st.MaxDuration)
+	}
+
+	for _, ev := range stats.Recent(5) {
+		fmt.Println(ev.QueryHash, ev.ExecutionStrategy, ev.TotalDuration)
+	}
+}
+```
+
+`pkg/ftsstats` is the recommended programmatic surface for agents and library consumers that need:
+
+- recent search events without storing raw query text by default;
+- aggregated stats by execution strategy;
+- structured observability without depending on `cmd/fts` or any HTTP/debug transport layer.
 
 ## Run main app (local testing via config)
 

--- a/readme.md
+++ b/readme.md
@@ -501,8 +501,10 @@ Use the index microbench when you want to measure low-level index operations in 
 
 It typically measures:
 
-- index lookup cost
+- exact lookup cost
+- positional lookup cost
 - insert cost
+- positional insert cost
 - allocations per operation
 
 It uses the same `go test` flags as the engine microbench.

--- a/readme.md
+++ b/readme.md
@@ -383,7 +383,7 @@ Snapshot fields (`fts.snapshot`):
 
 Use `cmd/bench` when you want to compare index/scorer/pipeline combinations on a corpus with labeled queries.
 
-In addition to indexing time and search quality metrics, `cmd/bench` now also reports aggregated search diagnostics such as strategy distribution, diagnostics timings, posting reads, and index lookups.
+In addition to indexing time and search quality metrics, `cmd/bench` can also report aggregated search diagnostics such as strategy distribution, diagnostics timings, posting reads, and index lookups. It also supports repeated runs with warmup and shuffled query order for more stable latency comparisons.
 
 Example:
 
@@ -395,7 +395,12 @@ go run ./cmd/bench \
   -lang en \
   -field abstract \
   -scorer bm25 \
-  -k 10
+  -k 10 \
+  -diagnostics true \
+  -observer false \
+  -warmup 20 \
+  -repeat 5 \
+  -shuffle true
 ```
 
 Useful flags:
@@ -407,6 +412,87 @@ Useful flags:
 - `-k`: top-k used for `nDCG` and `Recall`
 - `-limit`: cap the number of indexed documents for quick experiments
 - `-worst`: print worst queries by `nDCG`
+- `-diagnostics`: enable per-query `SearchResult.Diagnostics`
+- `-observer`: enable `ftsstats.SearchStats` aggregation during the benchmark run
+- `-warmup`: run N warmup searches before measured runs; warmup does not affect reported metrics
+- `-repeat`: repeat the full query set N times for measured runs
+- `-shuffle`: shuffle query order for warmup and each measured repeat with a fixed seed
+
+Local shard workloads checked in under `internal/bench/testdata/`:
+
+- `queries.abstract1.title.json`: tiny sanity-check workload for `-field title`
+- `queries.abstract1.abstract.json`: tiny sanity-check workload for `-field abstract`
+- `queries.abstract1.abstract.50.json`: curated 50-query `abstract` workload for repeated latency comparisons
+
+For local instrumentation comparisons on `./data/enwiki-20210820-abstract1.xml.gz`, use the curated 50-query abstract set:
+
+```bash
+go run ./cmd/bench \
+  -dump ./data/enwiki-20210820-abstract1.xml.gz \
+  -ground-truth ./internal/bench/testdata/queries.abstract1.abstract.50.json \
+  -index radix \
+  -lang en \
+  -field abstract \
+  -scorer simple \
+  -k 10 \
+  -warmup 50 \
+  -repeat 20 \
+  -shuffle true \
+  -diagnostics false \
+  -observer false
+```
+
+To compare instrumentation overhead, rerun the same command and vary only `-diagnostics` and `-observer`:
+
+```bash
+go run ./cmd/bench \
+  -dump ./data/enwiki-20210820-abstract1.xml.gz \
+  -ground-truth ./internal/bench/testdata/queries.abstract1.abstract.50.json \
+  -index radix \
+  -lang en \
+  -field abstract \
+  -scorer simple \
+  -k 10 \
+  -warmup 50 \
+  -repeat 20 \
+  -shuffle true \
+  -diagnostics true \
+  -observer false
+```
+
+```bash
+go run ./cmd/bench \
+  -dump ./data/enwiki-20210820-abstract1.xml.gz \
+  -ground-truth ./internal/bench/testdata/queries.abstract1.abstract.50.json \
+  -index radix \
+  -lang en \
+  -field abstract \
+  -scorer simple \
+  -k 10 \
+  -warmup 50 \
+  -repeat 20 \
+  -shuffle true \
+  -diagnostics false \
+  -observer true
+```
+
+```bash
+go run ./cmd/bench \
+  -dump ./data/enwiki-20210820-abstract1.xml.gz \
+  -ground-truth ./internal/bench/testdata/queries.abstract1.abstract.50.json \
+  -index radix \
+  -lang en \
+  -field abstract \
+  -scorer simple \
+  -k 10 \
+  -warmup 50 \
+  -repeat 20 \
+  -shuffle true \
+  -diagnostics true \
+  -observer true
+```
+
+Current latency numbers are measured around `SearchDocuments(...)`. `-observer` still exercises the observer path and prints observer summary, but observer work is not included in the reported `latency p50/p95/p99` yet.
 
 ### Benchmark baselines
 
@@ -418,6 +504,9 @@ For fair before/after comparisons keep these flags unchanged between runs:
 - `-field`
 - `-scorer`
 - `-k`
+- `-warmup`
+- `-repeat`
+- `-shuffle`
 
 Engine microbench:
 

--- a/readme.md
+++ b/readme.md
@@ -398,7 +398,7 @@ It measures:
 - indexing duration
 - search latency `p50/p95/p99`
 - quality metrics: `nDCG`, `MRR`, `Recall`
-- optional diagnostics: `diag.total`, `diag.search_tokens`, strategy distribution, posting reads, index lookups
+- optional diagnostics: `diag.total`, `diag.search_tokens`, strategy distribution, zero-result counts, WAND/fallback distributions, posting reads, index lookups
 
 Common flags:
 
@@ -410,7 +410,7 @@ Common flags:
 - `-scorer`: `simple|bm25|tfidf`
 - `-k`: top-k used for `nDCG` and `Recall`
 - `-limit`: cap the number of indexed documents for quick experiments
-- `-worst`: print worst queries by `nDCG` and slowest queries by latency
+- `-worst`: print worst queries by `nDCG`; with diagnostics enabled also print worst queries by `postings_read`
 - `-diagnostics`: enable per-query `SearchResult.Diagnostics`
 - `-observer`: enable `ftsstats.SearchStats` aggregation during the benchmark run
 - `-warmup`: run N warmup searches before measured runs; warmup does not affect reported metrics
@@ -470,7 +470,7 @@ To compare index implementations on the same corpus, keep all other flags the sa
 
 - `-index`
 
-Current latency numbers are measured around `SearchDocuments(...)`. `-observer` still exercises the observer path and prints observer summary, but observer work is not included in the reported `latency p50/p95/p99` yet.
+Current latency numbers are measured around `SearchDocuments(...)`. `-observer` still exercises the observer path and prints observer summary, but observer work is not included in the reported `latency p50/p95/p99` yet. The text report uses `p50/p95/p99` as the main latency view; the diagnostics-heavy breakdown focuses on strategies, postings, WAND usage, fallback reasons, and zero-result counts.
 
 ### 2) Engine Microbench
 
@@ -560,7 +560,7 @@ Recommended minimum baseline before a feature branch:
 Compare these outputs:
 
 - microbench: `ns/op`, `B/op`, `allocs/op`
-- `cmd/bench`: indexing duration, latency `p50/p95/p99`, `diag.total`, `diag.search_tokens`, `avg postings`, `avg index_lookups`, strategy distribution, `nDCG`, `MRR`, `Recall`
+- `cmd/bench`: indexing duration, latency `p50/p95/p99`, zero-result counts, `diag.total`, `diag.search_tokens`, `avg postings`, `avg index_lookups`, strategy distribution, WAND/fallback breakdowns, worst-by-postings, `nDCG`, `MRR`, `Recall`
 
 ## Ribbon filter usage
 


### PR DESCRIPTION
Adds structured query diagnostics to fts, exposes aggregated observer stats through pkg/ftsstats, and extends cmd/bench with strategy and internal-work reporting.