### PR TITLE
docs: clarify benchmark data path

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -344,6 +344,10 @@ Run the built-in suite script:
 MSMARCO_DIR=./data/msmarco ./benchmarks/scripts/run-suite.sh
 ```
 
+`run-suite.sh` runs benchmark commands from the `benchmarks/` module, so
+`MSMARCO_DIR=./data/msmarco` points at `./benchmarks/data/msmarco` when the script
+is launched from the repository root.
+
 Aggregate JSON shards:
 
 ```bash


### PR DESCRIPTION
## Summary
- clarify that `run-suite.sh` runs benchmark commands from the `benchmarks/` module
- explain why `MSMARCO_DIR=./data/msmarco` maps to `./benchmarks/data/msmarco` when launched from the repo root

## Validation
- `git diff --check`
- `sh -n benchmarks/scripts/run-suite.sh`
- `sh -n benchmarks/scripts/fetch-msmarco.sh`

Note: I did not run Go tests because this environment does not have the `go` toolchain installed.